### PR TITLE
Clean AWS_ environment vars between evals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@ This is a small utility that makes it easier to use the `aws sts assume-role` co
 
 ## Installation
 
+On OS X, the best way to get it is to use homebrew:
+
+```bash
+brew install remind101/formulae/assume-role
+```
+
+If you have a working Go 1.6 environment:
+
 ```bash
 $ go get -u github.com/remind101/assume-role
 ```


### PR DESCRIPTION
Fixes https://github.com/remind101/assume-role/issues/4

I keep running into https://github.com/remind101/assume-role/issues/4 and it's pretty annoying. This will clean out an previously set AWS_ environment variables before running the `aws sts` command to assume the role, if the `AWS_` environment variables were set by previously eval'ing.
