### PR TITLE
Add support for ~/.aws/config file

### DIFF
--- a/vendor/github.com/gopherjs/gopherjs/LICENSE
+++ b/vendor/github.com/gopherjs/gopherjs/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2013 Richard Musiol. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/gopherjs/gopherjs/js/js.go
+++ b/vendor/github.com/gopherjs/gopherjs/js/js.go
@@ -1,0 +1,168 @@
+// Package js provides functions for interacting with native JavaScript APIs. Calls to these functions are treated specially by GopherJS and translated directly to their corresponding JavaScript syntax.
+//
+// Use MakeWrapper to expose methods to JavaScript. When passing values directly, the following type conversions are performed:
+//
+//  | Go type               | JavaScript type       | Conversions back to interface{} |
+//  | --------------------- | --------------------- | ------------------------------- |
+//  | bool                  | Boolean               | bool                            |
+//  | integers and floats   | Number                | float64                         |
+//  | string                | String                | string                          |
+//  | []int8                | Int8Array             | []int8                          |
+//  | []int16               | Int16Array            | []int16                         |
+//  | []int32, []int        | Int32Array            | []int                           |
+//  | []uint8               | Uint8Array            | []uint8                         |
+//  | []uint16              | Uint16Array           | []uint16                        |
+//  | []uint32, []uint      | Uint32Array           | []uint                          |
+//  | []float32             | Float32Array          | []float32                       |
+//  | []float64             | Float64Array          | []float64                       |
+//  | all other slices      | Array                 | []interface{}                   |
+//  | arrays                | see slice type        | see slice type                  |
+//  | functions             | Function              | func(...interface{}) *js.Object |
+//  | time.Time             | Date                  | time.Time                       |
+//  | -                     | instanceof Node       | *js.Object                      |
+//  | maps, structs         | instanceof Object     | map[string]interface{}          |
+//
+// Additionally, for a struct containing a *js.Object field, only the content of the field will be passed to JavaScript and vice versa.
+package js
+
+// Object is a container for a native JavaScript object. Calls to its methods are treated specially by GopherJS and translated directly to their JavaScript syntax. A nil pointer to Object is equal to JavaScript's "null". Object can not be used as a map key.
+type Object struct{ object *Object }
+
+// Get returns the object's property with the given key.
+func (o *Object) Get(key string) *Object { return o.object.Get(key) }
+
+// Set assigns the value to the object's property with the given key.
+func (o *Object) Set(key string, value interface{}) { o.object.Set(key, value) }
+
+// Delete removes the object's property with the given key.
+func (o *Object) Delete(key string) { o.object.Delete(key) }
+
+// Length returns the object's "length" property, converted to int.
+func (o *Object) Length() int { return o.object.Length() }
+
+// Index returns the i'th element of an array.
+func (o *Object) Index(i int) *Object { return o.object.Index(i) }
+
+// SetIndex sets the i'th element of an array.
+func (o *Object) SetIndex(i int, value interface{}) { o.object.SetIndex(i, value) }
+
+// Call calls the object's method with the given name.
+func (o *Object) Call(name string, args ...interface{}) *Object { return o.object.Call(name, args...) }
+
+// Invoke calls the object itself. This will fail if it is not a function.
+func (o *Object) Invoke(args ...interface{}) *Object { return o.object.Invoke(args...) }
+
+// New creates a new instance of this type object. This will fail if it not a function (constructor).
+func (o *Object) New(args ...interface{}) *Object { return o.object.New(args...) }
+
+// Bool returns the object converted to bool according to JavaScript type conversions.
+func (o *Object) Bool() bool { return o.object.Bool() }
+
+// String returns the object converted to string according to JavaScript type conversions.
+func (o *Object) String() string { return o.object.String() }
+
+// Int returns the object converted to int according to JavaScript type conversions (parseInt).
+func (o *Object) Int() int { return o.object.Int() }
+
+// Int64 returns the object converted to int64 according to JavaScript type conversions (parseInt).
+func (o *Object) Int64() int64 { return o.object.Int64() }
+
+// Uint64 returns the object converted to uint64 according to JavaScript type conversions (parseInt).
+func (o *Object) Uint64() uint64 { return o.object.Uint64() }
+
+// Float returns the object converted to float64 according to JavaScript type conversions (parseFloat).
+func (o *Object) Float() float64 { return o.object.Float() }
+
+// Interface returns the object converted to interface{}. See GopherJS' README for details.
+func (o *Object) Interface() interface{} { return o.object.Interface() }
+
+// Unsafe returns the object as an uintptr, which can be converted via unsafe.Pointer. Not intended for public use.
+func (o *Object) Unsafe() uintptr { return o.object.Unsafe() }
+
+// Error encapsulates JavaScript errors. Those are turned into a Go panic and may be recovered, giving an *Error that holds the JavaScript error object.
+type Error struct {
+	*Object
+}
+
+// Error returns the message of the encapsulated JavaScript error object.
+func (err *Error) Error() string {
+	return "JavaScript error: " + err.Get("message").String()
+}
+
+// Stack returns the stack property of the encapsulated JavaScript error object.
+func (err *Error) Stack() string {
+	return err.Get("stack").String()
+}
+
+// Global gives JavaScript's global object ("window" for browsers and "GLOBAL" for Node.js).
+var Global *Object
+
+// Module gives the value of the "module" variable set by Node.js. Hint: Set a module export with 'js.Module.Get("exports").Set("exportName", ...)'.
+var Module *Object
+
+// Undefined gives the JavaScript value "undefined".
+var Undefined *Object
+
+// Debugger gets compiled to JavaScript's "debugger;" statement.
+func Debugger() {}
+
+// InternalObject returns the internal JavaScript object that represents i. Not intended for public use.
+func InternalObject(i interface{}) *Object {
+	return nil
+}
+
+// MakeFunc wraps a function and gives access to the values of JavaScript's "this" and "arguments" keywords.
+func MakeFunc(fn func(this *Object, arguments []*Object) interface{}) *Object {
+	return Global.Call("$makeFunc", InternalObject(fn))
+}
+
+// Keys returns the keys of the given JavaScript object.
+func Keys(o *Object) []string {
+	if o == nil || o == Undefined {
+		return nil
+	}
+	a := Global.Get("Object").Call("keys", o)
+	s := make([]string, a.Length())
+	for i := 0; i < a.Length(); i++ {
+		s[i] = a.Index(i).String()
+	}
+	return s
+}
+
+// MakeWrapper creates a JavaScript object which has wrappers for the exported methods of i. Use explicit getter and setter methods to expose struct fields to JavaScript.
+func MakeWrapper(i interface{}) *Object {
+	v := InternalObject(i)
+	o := Global.Get("Object").New()
+	o.Set("__internal_object__", v)
+	methods := v.Get("constructor").Get("methods")
+	for i := 0; i < methods.Length(); i++ {
+		m := methods.Index(i)
+		if m.Get("pkg").String() != "" { // not exported
+			continue
+		}
+		o.Set(m.Get("name").String(), func(args ...*Object) *Object {
+			return Global.Call("$externalizeFunction", v.Get(m.Get("prop").String()), m.Get("typ"), true).Call("apply", v, args)
+		})
+	}
+	return o
+}
+
+// NewArrayBuffer creates a JavaScript ArrayBuffer from a byte slice.
+func NewArrayBuffer(b []byte) *Object {
+	slice := InternalObject(b)
+	offset := slice.Get("$offset").Int()
+	length := slice.Get("$length").Int()
+	return slice.Get("$array").Get("buffer").Call("slice", offset, offset+length)
+}
+
+// M is a simple map type. It is intended as a shorthand for JavaScript objects (before conversion).
+type M map[string]interface{}
+
+// S is a simple slice type. It is intended as a shorthand for JavaScript arrays (before conversion).
+type S []interface{}
+
+func init() {
+	// avoid dead code elimination
+	e := Error{}
+	_ = e
+}

--- a/vendor/github.com/gopherjs/gopherjs/js/js_test.go
+++ b/vendor/github.com/gopherjs/gopherjs/js/js_test.go
@@ -1,0 +1,573 @@
+// +build js
+
+package js_test
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gopherjs/gopherjs/js"
+)
+
+var dummys = js.Global.Call("eval", `({
+	someBool: true,
+	someString: "abc\u1234",
+	someInt: 42,
+	someFloat: 42.123,
+	someArray: [41, 42, 43],
+	add: function(a, b) {
+		return a + b;
+	},
+	mapArray: function(array, f) {
+		var newArray = new Array(array.length);
+		for (var i = 0; i < array.length; i++) {
+			newArray[i] = f(array[i]);
+		}
+		return newArray;
+	},
+	toUnixTimestamp: function(d) {
+		return d.getTime() / 1000;
+	},
+	testField: function(o) {
+		return o.Field;
+	},
+	testMethod: function(o) {
+		return o.Method(42);
+	},
+	isEqual: function(a, b) {
+		return a === b;
+	},
+	call: function(f, a) {
+		f(a);
+	},
+	return: function(x) {
+		return x;
+	},
+})`)
+
+func TestBool(t *testing.T) {
+	e := true
+	o := dummys.Get("someBool")
+	if v := o.Bool(); v != e {
+		t.Errorf("expected %#v, got %#v", e, v)
+	}
+	if i := o.Interface().(bool); i != e {
+		t.Errorf("expected %#v, got %#v", e, i)
+	}
+	if dummys.Set("otherBool", e); dummys.Get("otherBool").Bool() != e {
+		t.Fail()
+	}
+}
+
+func TestStr(t *testing.T) {
+	e := "abc\u1234"
+	o := dummys.Get("someString")
+	if v := o.String(); v != e {
+		t.Errorf("expected %#v, got %#v", e, v)
+	}
+	if i := o.Interface().(string); i != e {
+		t.Errorf("expected %#v, got %#v", e, i)
+	}
+	if dummys.Set("otherString", e); dummys.Get("otherString").String() != e {
+		t.Fail()
+	}
+}
+
+func TestInt(t *testing.T) {
+	e := 42
+	o := dummys.Get("someInt")
+	if v := o.Int(); v != e {
+		t.Errorf("expected %#v, got %#v", e, v)
+	}
+	if i := int(o.Interface().(float64)); i != e {
+		t.Errorf("expected %#v, got %#v", e, i)
+	}
+	if dummys.Set("otherInt", e); dummys.Get("otherInt").Int() != e {
+		t.Fail()
+	}
+}
+
+func TestFloat(t *testing.T) {
+	e := 42.123
+	o := dummys.Get("someFloat")
+	if v := o.Float(); v != e {
+		t.Errorf("expected %#v, got %#v", e, v)
+	}
+	if i := o.Interface().(float64); i != e {
+		t.Errorf("expected %#v, got %#v", e, i)
+	}
+	if dummys.Set("otherFloat", e); dummys.Get("otherFloat").Float() != e {
+		t.Fail()
+	}
+}
+
+func TestUndefined(t *testing.T) {
+	if dummys == js.Undefined || dummys.Get("xyz") != js.Undefined {
+		t.Fail()
+	}
+}
+
+func TestNull(t *testing.T) {
+	var null *js.Object
+	dummys.Set("test", nil)
+	if null != nil || dummys == nil || dummys.Get("test") != nil {
+		t.Fail()
+	}
+}
+
+func TestLength(t *testing.T) {
+	if dummys.Get("someArray").Length() != 3 {
+		t.Fail()
+	}
+}
+
+func TestIndex(t *testing.T) {
+	if dummys.Get("someArray").Index(1).Int() != 42 {
+		t.Fail()
+	}
+}
+
+func TestSetIndex(t *testing.T) {
+	dummys.Get("someArray").SetIndex(2, 99)
+	if dummys.Get("someArray").Index(2).Int() != 99 {
+		t.Fail()
+	}
+}
+
+func TestCall(t *testing.T) {
+	var i int64 = 40
+	if dummys.Call("add", i, 2).Int() != 42 {
+		t.Fail()
+	}
+	if dummys.Call("add", js.Global.Call("eval", "40"), 2).Int() != 42 {
+		t.Fail()
+	}
+}
+
+func TestInvoke(t *testing.T) {
+	var i int64 = 40
+	if dummys.Get("add").Invoke(i, 2).Int() != 42 {
+		t.Fail()
+	}
+}
+
+func TestNew(t *testing.T) {
+	if js.Global.Get("Array").New(42).Length() != 42 {
+		t.Fail()
+	}
+}
+
+type StructWithJsField1 struct {
+	*js.Object
+	Length int                  `js:"length"`
+	Slice  func(int, int) []int `js:"slice"`
+}
+
+type StructWithJsField2 struct {
+	object *js.Object           // to hide members from public API
+	Length int                  `js:"length"`
+	Slice  func(int, int) []int `js:"slice"`
+}
+
+type Wrapper1 struct {
+	StructWithJsField1
+	WrapperLength int `js:"length"`
+}
+
+type Wrapper2 struct {
+	innerStruct   *StructWithJsField2
+	WrapperLength int `js:"length"`
+}
+
+func TestReadingJsField(t *testing.T) {
+	a := StructWithJsField1{Object: js.Global.Get("Array").New(42)}
+	b := &StructWithJsField2{object: js.Global.Get("Array").New(42)}
+	wa := Wrapper1{StructWithJsField1: a}
+	wb := Wrapper2{innerStruct: b}
+	if a.Length != 42 || b.Length != 42 || wa.Length != 42 || wa.WrapperLength != 42 || wb.WrapperLength != 42 {
+		t.Fail()
+	}
+}
+
+func TestWritingJsField(t *testing.T) {
+	a := StructWithJsField1{Object: js.Global.Get("Object").New()}
+	b := &StructWithJsField2{object: js.Global.Get("Object").New()}
+	a.Length = 42
+	b.Length = 42
+	if a.Get("length").Int() != 42 || b.object.Get("length").Int() != 42 {
+		t.Fail()
+	}
+}
+
+func TestCallingJsField(t *testing.T) {
+	a := &StructWithJsField1{Object: js.Global.Get("Array").New(100)}
+	b := &StructWithJsField2{object: js.Global.Get("Array").New(100)}
+	a.SetIndex(3, 123)
+	b.object.SetIndex(3, 123)
+	f := a.Slice
+	a2 := a.Slice(2, 44)
+	b2 := b.Slice(2, 44)
+	c2 := f(2, 44)
+	if len(a2) != 42 || len(b2) != 42 || len(c2) != 42 || a2[1] != 123 || b2[1] != 123 || c2[1] != 123 {
+		t.Fail()
+	}
+}
+
+func TestReflectionOnJsField(t *testing.T) {
+	a := StructWithJsField1{Object: js.Global.Get("Array").New(42)}
+	wa := Wrapper1{StructWithJsField1: a}
+	if reflect.ValueOf(a).FieldByName("Length").Int() != 42 || reflect.ValueOf(&wa).Elem().FieldByName("WrapperLength").Int() != 42 {
+		t.Fail()
+	}
+	reflect.ValueOf(&wa).Elem().FieldByName("WrapperLength").Set(reflect.ValueOf(10))
+	if a.Length != 10 {
+		t.Fail()
+	}
+}
+
+func TestUnboxing(t *testing.T) {
+	a := StructWithJsField1{Object: js.Global.Get("Object").New()}
+	b := &StructWithJsField2{object: js.Global.Get("Object").New()}
+	if !dummys.Call("isEqual", a, a.Object).Bool() || !dummys.Call("isEqual", b, b.object).Bool() {
+		t.Fail()
+	}
+	wa := Wrapper1{StructWithJsField1: a}
+	wb := Wrapper2{innerStruct: b}
+	if !dummys.Call("isEqual", wa, a.Object).Bool() || !dummys.Call("isEqual", wb, b.object).Bool() {
+		t.Fail()
+	}
+}
+
+func TestBoxing(t *testing.T) {
+	o := js.Global.Get("Object").New()
+	dummys.Call("call", func(a StructWithJsField1) {
+		if a.Object != o {
+			t.Fail()
+		}
+	}, o)
+	dummys.Call("call", func(a *StructWithJsField2) {
+		if a.object != o {
+			t.Fail()
+		}
+	}, o)
+	dummys.Call("call", func(a Wrapper1) {
+		if a.Object != o {
+			t.Fail()
+		}
+	}, o)
+	dummys.Call("call", func(a Wrapper2) {
+		if a.innerStruct.object != o {
+			t.Fail()
+		}
+	}, o)
+}
+
+func TestFunc(t *testing.T) {
+	a := dummys.Call("mapArray", []int{1, 2, 3}, func(e int64) int64 { return e + 40 })
+	b := dummys.Call("mapArray", []int{1, 2, 3}, func(e ...int64) int64 { return e[0] + 40 })
+	if a.Index(1).Int() != 42 || b.Index(1).Int() != 42 {
+		t.Fail()
+	}
+
+	add := dummys.Get("add").Interface().(func(...interface{}) *js.Object)
+	var i int64 = 40
+	if add(i, 2).Int() != 42 {
+		t.Fail()
+	}
+}
+
+func TestDate(t *testing.T) {
+	d := time.Date(2013, time.August, 27, 22, 25, 11, 0, time.UTC)
+	if dummys.Call("toUnixTimestamp", d).Int() != int(d.Unix()) {
+		t.Fail()
+	}
+
+	d2 := js.Global.Get("Date").New(d.UnixNano() / 1000000).Interface().(time.Time)
+	if !d2.Equal(d) {
+		t.Fail()
+	}
+}
+
+// https://github.com/gopherjs/gopherjs/issues/287
+func TestInternalizeDate(t *testing.T) {
+	var a = time.Unix(0, (123 * time.Millisecond).Nanoseconds())
+	var b time.Time
+	js.Global.Set("internalizeDate", func(t time.Time) { b = t })
+	js.Global.Call("eval", "(internalizeDate(new Date(123)))")
+	if a != b {
+		t.Fail()
+	}
+}
+
+func TestEquality(t *testing.T) {
+	if js.Global.Get("Array") != js.Global.Get("Array") || js.Global.Get("Array") == js.Global.Get("String") {
+		t.Fail()
+	}
+	type S struct{ *js.Object }
+	o1 := js.Global.Get("Object").New()
+	o2 := js.Global.Get("Object").New()
+	a := S{o1}
+	b := S{o1}
+	c := S{o2}
+	if a != b || a == c {
+		t.Fail()
+	}
+}
+
+func TestUndefinedEquality(t *testing.T) {
+	var ui interface{} = js.Undefined
+	if ui != js.Undefined {
+		t.Fail()
+	}
+}
+
+func TestInterfaceEquality(t *testing.T) {
+	o := js.Global.Get("Object").New()
+	var i interface{} = o
+	if i != o {
+		t.Fail()
+	}
+}
+
+func TestUndefinedInternalization(t *testing.T) {
+	undefinedEqualsJsUndefined := func(i interface{}) bool {
+		return i == js.Undefined
+	}
+	js.Global.Set("undefinedEqualsJsUndefined", undefinedEqualsJsUndefined)
+	if !js.Global.Call("eval", "(undefinedEqualsJsUndefined(undefined))").Bool() {
+		t.Fail()
+	}
+}
+
+func TestSameFuncWrapper(t *testing.T) {
+	a := func(_ string) {} // string argument to force wrapping
+	b := func(_ string) {} // string argument to force wrapping
+	if !dummys.Call("isEqual", a, a).Bool() || dummys.Call("isEqual", a, b).Bool() {
+		t.Fail()
+	}
+	if !dummys.Call("isEqual", somePackageFunction, somePackageFunction).Bool() {
+		t.Fail()
+	}
+	if !dummys.Call("isEqual", (*T).someMethod, (*T).someMethod).Bool() {
+		t.Fail()
+	}
+	t1 := &T{}
+	t2 := &T{}
+	if !dummys.Call("isEqual", t1.someMethod, t1.someMethod).Bool() || dummys.Call("isEqual", t1.someMethod, t2.someMethod).Bool() {
+		t.Fail()
+	}
+}
+
+func somePackageFunction(_ string) {
+}
+
+type T struct{}
+
+func (t *T) someMethod() {
+	println(42)
+}
+
+func TestError(t *testing.T) {
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Fail()
+		}
+		if _, ok := err.(error); !ok {
+			t.Fail()
+		}
+		jsErr, ok := err.(*js.Error)
+		if !ok || !strings.Contains(jsErr.Error(), "throwsError") {
+			t.Fail()
+		}
+	}()
+	js.Global.Get("notExisting").Call("throwsError")
+}
+
+type F struct {
+	Field int
+}
+
+func TestExternalizeField(t *testing.T) {
+	if dummys.Call("testField", map[string]int{"Field": 42}).Int() != 42 {
+		t.Fail()
+	}
+	if dummys.Call("testField", F{42}).Int() != 42 {
+		t.Fail()
+	}
+}
+
+func TestMakeFunc(t *testing.T) {
+	o := js.Global.Get("Object").New()
+	for i := 3; i < 5; i++ {
+		x := i
+		if i == 4 {
+			break
+		}
+		o.Set("f", js.MakeFunc(func(this *js.Object, arguments []*js.Object) interface{} {
+			if this != o {
+				t.Fail()
+			}
+			if len(arguments) != 2 || arguments[0].Int() != 1 || arguments[1].Int() != 2 {
+				t.Fail()
+			}
+			return x
+		}))
+	}
+	if o.Call("f", 1, 2).Int() != 3 {
+		t.Fail()
+	}
+}
+
+type M struct {
+	f int
+}
+
+func (m *M) Method(a interface{}) map[string]string {
+	if a.(map[string]interface{})["x"].(float64) != 1 || m.f != 42 {
+		return nil
+	}
+	return map[string]string{
+		"y": "z",
+	}
+}
+
+func TestMakeWrapper(t *testing.T) {
+	m := &M{42}
+	if !js.Global.Call("eval", `(function(m) { return m.Method({x: 1})["y"] === "z"; })`).Invoke(js.MakeWrapper(m)).Bool() {
+		t.Fail()
+	}
+
+	if js.MakeWrapper(m).Interface() != m {
+		t.Fail()
+	}
+
+	f := func(m *M) {
+		if m.f != 42 {
+			t.Fail()
+		}
+	}
+	js.Global.Call("eval", `(function(f, m) { f(m); })`).Invoke(f, js.MakeWrapper(m))
+}
+
+func TestCallWithNull(t *testing.T) {
+	c := make(chan int, 1)
+	js.Global.Set("test", func() {
+		c <- 42
+	})
+	js.Global.Get("test").Call("call", nil)
+	if <-c != 42 {
+		t.Fail()
+	}
+}
+
+func TestReflection(t *testing.T) {
+	o := js.Global.Call("eval", "({ answer: 42 })")
+	if reflect.ValueOf(o).Interface().(*js.Object) != o {
+		t.Fail()
+	}
+
+	type S struct {
+		Field *js.Object
+	}
+	s := S{o}
+
+	v := reflect.ValueOf(&s).Elem()
+	if v.Field(0).Interface().(*js.Object).Get("answer").Int() != 42 {
+		t.Fail()
+	}
+	if v.Field(0).MethodByName("Get").Call([]reflect.Value{reflect.ValueOf("answer")})[0].Interface().(*js.Object).Int() != 42 {
+		t.Fail()
+	}
+	v.Field(0).Set(reflect.ValueOf(js.Global.Call("eval", "({ answer: 100 })")))
+	if s.Field.Get("answer").Int() != 100 {
+		t.Fail()
+	}
+
+	if fmt.Sprintf("%+v", s) != "{Field:[object Object]}" {
+		t.Fail()
+	}
+}
+
+func TestNil(t *testing.T) {
+	type S struct{ X int }
+	var s *S
+	if !dummys.Call("isEqual", s, nil).Bool() {
+		t.Fail()
+	}
+
+	type T struct{ Field *S }
+	if dummys.Call("testField", T{}) != nil {
+		t.Fail()
+	}
+}
+
+func TestNewArrayBuffer(t *testing.T) {
+	b := []byte("abcd")
+	a := js.NewArrayBuffer(b[1:3])
+	if a.Get("byteLength").Int() != 2 {
+		t.Fail()
+	}
+}
+
+func TestInternalizeExternalizeNull(t *testing.T) {
+	type S struct {
+		*js.Object
+	}
+	r := js.Global.Call("eval", "(function(f) { return f(null); })").Invoke(func(s S) S {
+		if s.Object != nil {
+			t.Fail()
+		}
+		return s
+	})
+	if r != nil {
+		t.Fail()
+	}
+}
+
+func TestInternalizeExternalizeUndefined(t *testing.T) {
+	type S struct {
+		*js.Object
+	}
+	r := js.Global.Call("eval", "(function(f) { return f(undefined); })").Invoke(func(s S) S {
+		if s.Object != js.Undefined {
+			t.Fail()
+		}
+		return s
+	})
+	if r != js.Undefined {
+		t.Fail()
+	}
+}
+
+func TestDereference(t *testing.T) {
+	s := *dummys
+	p := &s
+	if p != dummys {
+		t.Fail()
+	}
+}
+
+func TestSurrogatePairs(t *testing.T) {
+	js.Global.Set("str", "\U0001F600")
+	str := js.Global.Get("str")
+	if str.Get("length").Int() != 2 || str.Call("charCodeAt", 0).Int() != 55357 || str.Call("charCodeAt", 1).Int() != 56832 {
+		t.Fail()
+	}
+	if str.String() != "\U0001F600" {
+		t.Fail()
+	}
+}
+
+func TestUint8Array(t *testing.T) {
+	uint8Array := js.Global.Get("Uint8Array")
+	if dummys.Call("return", []byte{}).Get("constructor") != uint8Array {
+		t.Errorf("Empty byte array is not externalized as a Uint8Array")
+	}
+	if dummys.Call("return", []byte{0x01}).Get("constructor") != uint8Array {
+		t.Errorf("Non-empty byte array is not externalized as a Uint8Array")
+	}
+}

--- a/vendor/github.com/jtolds/gls/LICENSE
+++ b/vendor/github.com/jtolds/gls/LICENSE
@@ -1,0 +1,18 @@
+Copyright (c) 2013, Space Monkey, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/jtolds/gls/README.md
+++ b/vendor/github.com/jtolds/gls/README.md
@@ -1,0 +1,89 @@
+gls
+===
+
+Goroutine local storage
+
+### IMPORTANT NOTE ###
+
+It is my duty to point you to https://blog.golang.org/context, which is how 
+Google solves all of the problems you'd perhaps consider using this package
+for at scale. 
+
+One downside to Google's approach is that *all* of your functions must have
+a new first argument, but after clearing that hurdle everything else is much
+better.
+
+If you aren't interested in this warning, read on.
+
+### Huhwaht? Why? ###
+
+Every so often, a thread shows up on the
+[golang-nuts](https://groups.google.com/d/forum/golang-nuts) asking for some
+form of goroutine-local-storage, or some kind of goroutine id, or some kind of
+context. There are a few valid use cases for goroutine-local-storage, one of
+the most prominent being log line context. One poster was interested in being
+able to log an HTTP request context id in every log line in the same goroutine
+as the incoming HTTP request, without having to change every library and
+function call he was interested in logging.
+
+This would be pretty useful. Provided that you could get some kind of
+goroutine-local-storage, you could call
+[log.SetOutput](http://golang.org/pkg/log/#SetOutput) with your own logging
+writer that checks goroutine-local-storage for some context information and
+adds that context to your log lines.
+
+But alas, Andrew Gerrand's typically diplomatic answer to the question of
+goroutine-local variables was:
+
+> We wouldn't even be having this discussion if thread local storage wasn't
+> useful. But every feature comes at a cost, and in my opinion the cost of
+> threadlocals far outweighs their benefits. They're just not a good fit for
+> Go.
+
+So, yeah, that makes sense. That's a pretty good reason for why the language
+won't support a specific and (relatively) unuseful feature that requires some
+runtime changes, just for the sake of a little bit of log improvement.
+
+But does Go require runtime changes?
+
+### How it works ###
+
+Go has pretty fantastic introspective and reflective features, but one thing Go
+doesn't give you is any kind of access to the stack pointer, or frame pointer,
+or goroutine id, or anything contextual about your current stack. It gives you
+access to your list of callers, but only along with program counters, which are
+fixed at compile time.
+
+But it does give you the stack.
+
+So, we define 16 special functions and embed base-16 tags into the stack using
+the call order of those 16 functions. Then, we can read our tags back out of
+the stack looking at the callers list.
+
+We then use these tags as an index into a traditional map for implementing
+this library.
+
+### What are people saying? ###
+
+"Wow, that's horrifying."
+
+"This is the most terrible thing I have seen in a very long time."
+
+"Where is it getting a context from? Is this serializing all the requests? 
+What the heck is the client being bound to? What are these tags? Why does he 
+need callers? Oh god no. No no no."
+
+### Docs ###
+
+Please see the docs at http://godoc.org/github.com/jtolds/gls
+
+### Related ###
+
+If you're okay relying on the string format of the current runtime stacktrace 
+including a unique goroutine id (not guaranteed by the spec or anything, but 
+very unlikely to change within a Go release), you might be able to squeeze 
+out a bit more performance by using this similar library, inspired by some 
+code Brad Fitzpatrick wrote for debugging his HTTP/2 library: 
+https://github.com/tylerb/gls (in contrast, jtolds/gls doesn't require 
+any knowledge of the string format of the runtime stacktrace, which 
+probably adds unnecessary overhead).

--- a/vendor/github.com/jtolds/gls/context.go
+++ b/vendor/github.com/jtolds/gls/context.go
@@ -1,0 +1,153 @@
+// Package gls implements goroutine-local storage.
+package gls
+
+import (
+	"sync"
+)
+
+var (
+	mgrRegistry    = make(map[*ContextManager]bool)
+	mgrRegistryMtx sync.RWMutex
+)
+
+// Values is simply a map of key types to value types. Used by SetValues to
+// set multiple values at once.
+type Values map[interface{}]interface{}
+
+// ContextManager is the main entrypoint for interacting with
+// Goroutine-local-storage. You can have multiple independent ContextManagers
+// at any given time. ContextManagers are usually declared globally for a given
+// class of context variables. You should use NewContextManager for
+// construction.
+type ContextManager struct {
+	mtx    sync.Mutex
+	values map[uint]Values
+}
+
+// NewContextManager returns a brand new ContextManager. It also registers the
+// new ContextManager in the ContextManager registry which is used by the Go
+// method. ContextManagers are typically defined globally at package scope.
+func NewContextManager() *ContextManager {
+	mgr := &ContextManager{values: make(map[uint]Values)}
+	mgrRegistryMtx.Lock()
+	defer mgrRegistryMtx.Unlock()
+	mgrRegistry[mgr] = true
+	return mgr
+}
+
+// Unregister removes a ContextManager from the global registry, used by the
+// Go method. Only intended for use when you're completely done with a
+// ContextManager. Use of Unregister at all is rare.
+func (m *ContextManager) Unregister() {
+	mgrRegistryMtx.Lock()
+	defer mgrRegistryMtx.Unlock()
+	delete(mgrRegistry, m)
+}
+
+// SetValues takes a collection of values and a function to call for those
+// values to be set in. Anything further down the stack will have the set
+// values available through GetValue. SetValues will add new values or replace
+// existing values of the same key and will not mutate or change values for
+// previous stack frames.
+// SetValues is slow (makes a copy of all current and new values for the new
+// gls-context) in order to reduce the amount of lookups GetValue requires.
+func (m *ContextManager) SetValues(new_values Values, context_call func()) {
+	if len(new_values) == 0 {
+		context_call()
+		return
+	}
+
+	mutated_keys := make([]interface{}, 0, len(new_values))
+	mutated_vals := make(Values, len(new_values))
+
+	EnsureGoroutineId(func(gid uint) {
+		m.mtx.Lock()
+		state, found := m.values[gid]
+		if !found {
+			state = make(Values, len(new_values))
+			m.values[gid] = state
+		}
+		m.mtx.Unlock()
+
+		for key, new_val := range new_values {
+			mutated_keys = append(mutated_keys, key)
+			if old_val, ok := state[key]; ok {
+				mutated_vals[key] = old_val
+			}
+			state[key] = new_val
+		}
+
+		defer func() {
+			if !found {
+				m.mtx.Lock()
+				delete(m.values, gid)
+				m.mtx.Unlock()
+				return
+			}
+
+			for _, key := range mutated_keys {
+				if val, ok := mutated_vals[key]; ok {
+					state[key] = val
+				} else {
+					delete(state, key)
+				}
+			}
+		}()
+
+		context_call()
+	})
+}
+
+// GetValue will return a previously set value, provided that the value was set
+// by SetValues somewhere higher up the stack. If the value is not found, ok
+// will be false.
+func (m *ContextManager) GetValue(key interface{}) (
+	value interface{}, ok bool) {
+	gid, ok := GetGoroutineId()
+	if !ok {
+		return nil, false
+	}
+
+	m.mtx.Lock()
+	state, found := m.values[gid]
+	m.mtx.Unlock()
+
+	if !found {
+		return nil, false
+	}
+	value, ok = state[key]
+	return value, ok
+}
+
+func (m *ContextManager) getValues() Values {
+	gid, ok := GetGoroutineId()
+	if !ok {
+		return nil
+	}
+	m.mtx.Lock()
+	state, _ := m.values[gid]
+	m.mtx.Unlock()
+	return state
+}
+
+// Go preserves ContextManager values and Goroutine-local-storage across new
+// goroutine invocations. The Go method makes a copy of all existing values on
+// all registered context managers and makes sure they are still set after
+// kicking off the provided function in a new goroutine. If you don't use this
+// Go method instead of the standard 'go' keyword, you will lose values in
+// ContextManagers, as goroutines have brand new stacks.
+func Go(cb func()) {
+	mgrRegistryMtx.RLock()
+	defer mgrRegistryMtx.RUnlock()
+
+	for mgr := range mgrRegistry {
+		values := mgr.getValues()
+		if len(values) > 0 {
+			cb = func(mgr *ContextManager, cb func()) func() {
+				return func() { mgr.SetValues(values, cb) }
+			}(mgr, cb)
+		}
+	}
+
+	go cb()
+}

--- a/vendor/github.com/jtolds/gls/context_test.go
+++ b/vendor/github.com/jtolds/gls/context_test.go
@@ -1,0 +1,145 @@
+package gls_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/jtolds/gls"
+)
+
+func TestContexts(t *testing.T) {
+	mgr1 := gls.NewContextManager()
+	mgr2 := gls.NewContextManager()
+
+	CheckVal := func(mgr *gls.ContextManager, key, exp_val string) {
+		val, ok := mgr.GetValue(key)
+		if len(exp_val) == 0 {
+			if ok {
+				t.Fatalf("expected no value for key %s, got %s", key, val)
+			}
+			return
+		}
+		if !ok {
+			t.Fatalf("expected value %s for key %s, got no value",
+				exp_val, key)
+		}
+		if exp_val != val {
+			t.Fatalf("expected value %s for key %s, got %s", exp_val, key,
+				val)
+		}
+
+	}
+
+	Check := func(exp_m1v1, exp_m1v2, exp_m2v1, exp_m2v2 string) {
+		CheckVal(mgr1, "key1", exp_m1v1)
+		CheckVal(mgr1, "key2", exp_m1v2)
+		CheckVal(mgr2, "key1", exp_m2v1)
+		CheckVal(mgr2, "key2", exp_m2v2)
+	}
+
+	Check("", "", "", "")
+	mgr2.SetValues(gls.Values{"key1": "val1c"}, func() {
+		Check("", "", "val1c", "")
+		mgr1.SetValues(gls.Values{"key1": "val1a"}, func() {
+			Check("val1a", "", "val1c", "")
+			mgr1.SetValues(gls.Values{"key2": "val1b"}, func() {
+				Check("val1a", "val1b", "val1c", "")
+				var wg sync.WaitGroup
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					Check("", "", "", "")
+				}()
+				gls.Go(func() {
+					defer wg.Done()
+					Check("val1a", "val1b", "val1c", "")
+				})
+				wg.Wait()
+				Check("val1a", "val1b", "val1c", "")
+			})
+			Check("val1a", "", "val1c", "")
+		})
+		Check("", "", "val1c", "")
+	})
+	Check("", "", "", "")
+}
+
+func ExampleContextManager_SetValues() {
+	var (
+		mgr            = gls.NewContextManager()
+		request_id_key = gls.GenSym()
+	)
+
+	MyLog := func() {
+		if request_id, ok := mgr.GetValue(request_id_key); ok {
+			fmt.Println("My request id is:", request_id)
+		} else {
+			fmt.Println("No request id found")
+		}
+	}
+
+	mgr.SetValues(gls.Values{request_id_key: "12345"}, func() {
+		MyLog()
+	})
+	MyLog()
+
+	// Output: My request id is: 12345
+	// No request id found
+}
+
+func ExampleGo() {
+	var (
+		mgr            = gls.NewContextManager()
+		request_id_key = gls.GenSym()
+	)
+
+	MyLog := func() {
+		if request_id, ok := mgr.GetValue(request_id_key); ok {
+			fmt.Println("My request id is:", request_id)
+		} else {
+			fmt.Println("No request id found")
+		}
+	}
+
+	mgr.SetValues(gls.Values{request_id_key: "12345"}, func() {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			MyLog()
+		}()
+		wg.Wait()
+		wg.Add(1)
+		gls.Go(func() {
+			defer wg.Done()
+			MyLog()
+		})
+		wg.Wait()
+	})
+
+	// Output: No request id found
+	// My request id is: 12345
+}
+
+func BenchmarkGetValue(b *testing.B) {
+	mgr := gls.NewContextManager()
+	mgr.SetValues(gls.Values{"test_key": "test_val"}, func() {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			val, ok := mgr.GetValue("test_key")
+			if !ok || val != "test_val" {
+				b.FailNow()
+			}
+		}
+	})
+}
+
+func BenchmarkSetValues(b *testing.B) {
+	mgr := gls.NewContextManager()
+	for i := 0; i < b.N/2; i++ {
+		mgr.SetValues(gls.Values{"test_key": "test_val"}, func() {
+			mgr.SetValues(gls.Values{"test_key2": "test_val2"}, func() {})
+		})
+	}
+}

--- a/vendor/github.com/jtolds/gls/gen_sym.go
+++ b/vendor/github.com/jtolds/gls/gen_sym.go
@@ -1,0 +1,21 @@
+package gls
+
+import (
+	"sync"
+)
+
+var (
+	keyMtx     sync.Mutex
+	keyCounter uint64
+)
+
+// ContextKey is a throwaway value you can use as a key to a ContextManager
+type ContextKey struct{ id uint64 }
+
+// GenSym will return a brand new, never-before-used ContextKey
+func GenSym() ContextKey {
+	keyMtx.Lock()
+	defer keyMtx.Unlock()
+	keyCounter += 1
+	return ContextKey{id: keyCounter}
+}

--- a/vendor/github.com/jtolds/gls/gid.go
+++ b/vendor/github.com/jtolds/gls/gid.go
@@ -1,0 +1,25 @@
+package gls
+
+var (
+	stackTagPool = &idPool{}
+)
+
+// Will return this goroutine's identifier if set. If you always need a
+// goroutine identifier, you should use EnsureGoroutineId which will make one
+// if there isn't one already.
+func GetGoroutineId() (gid uint, ok bool) {
+	return readStackTag()
+}
+
+// Will call cb with the current goroutine identifier. If one hasn't already
+// been generated, one will be created and set first. The goroutine identifier
+// might be invalid after cb returns.
+func EnsureGoroutineId(cb func(gid uint)) {
+	if gid, ok := readStackTag(); ok {
+		cb(gid)
+		return
+	}
+	gid := stackTagPool.Acquire()
+	defer stackTagPool.Release(gid)
+	addStackTag(gid, func() { cb(gid) })
+}

--- a/vendor/github.com/jtolds/gls/id_pool.go
+++ b/vendor/github.com/jtolds/gls/id_pool.go
@@ -1,0 +1,34 @@
+package gls
+
+// though this could probably be better at keeping ids smaller, the goal of
+// this class is to keep a registry of the smallest unique integer ids
+// per-process possible
+
+import (
+	"sync"
+)
+
+type idPool struct {
+	mtx      sync.Mutex
+	released []uint
+	max_id   uint
+}
+
+func (p *idPool) Acquire() (id uint) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	if len(p.released) > 0 {
+		id = p.released[len(p.released)-1]
+		p.released = p.released[:len(p.released)-1]
+		return id
+	}
+	id = p.max_id
+	p.max_id++
+	return id
+}
+
+func (p *idPool) Release(id uint) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.released = append(p.released, id)
+}

--- a/vendor/github.com/jtolds/gls/stack_tags.go
+++ b/vendor/github.com/jtolds/gls/stack_tags.go
@@ -1,0 +1,108 @@
+package gls
+
+// so, basically, we're going to encode integer tags in base-16 on the stack
+
+const (
+	bitWidth       = 4
+	stackBatchSize = 16
+)
+
+var (
+	pc_lookup   = make(map[uintptr]int8, 17)
+	mark_lookup [16]func(uint, func())
+)
+
+func init() {
+	setEntries := func(f func(uint, func()), v int8) {
+		var ptr uintptr
+		f(0, func() {
+			ptr = findPtr()
+		})
+		pc_lookup[ptr] = v
+		if v >= 0 {
+			mark_lookup[v] = f
+		}
+	}
+	setEntries(github_com_jtolds_gls_markS, -0x1)
+	setEntries(github_com_jtolds_gls_mark0, 0x0)
+	setEntries(github_com_jtolds_gls_mark1, 0x1)
+	setEntries(github_com_jtolds_gls_mark2, 0x2)
+	setEntries(github_com_jtolds_gls_mark3, 0x3)
+	setEntries(github_com_jtolds_gls_mark4, 0x4)
+	setEntries(github_com_jtolds_gls_mark5, 0x5)
+	setEntries(github_com_jtolds_gls_mark6, 0x6)
+	setEntries(github_com_jtolds_gls_mark7, 0x7)
+	setEntries(github_com_jtolds_gls_mark8, 0x8)
+	setEntries(github_com_jtolds_gls_mark9, 0x9)
+	setEntries(github_com_jtolds_gls_markA, 0xa)
+	setEntries(github_com_jtolds_gls_markB, 0xb)
+	setEntries(github_com_jtolds_gls_markC, 0xc)
+	setEntries(github_com_jtolds_gls_markD, 0xd)
+	setEntries(github_com_jtolds_gls_markE, 0xe)
+	setEntries(github_com_jtolds_gls_markF, 0xf)
+}
+
+func addStackTag(tag uint, context_call func()) {
+	if context_call == nil {
+		return
+	}
+	github_com_jtolds_gls_markS(tag, context_call)
+}
+
+// these private methods are named this horrendous name so gopherjs support
+// is easier. it shouldn't add any runtime cost in non-js builds.
+func github_com_jtolds_gls_markS(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark0(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark1(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark2(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark3(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark4(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark5(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark6(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark7(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark8(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark9(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_markA(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_markB(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_markC(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_markD(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_markE(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_markF(tag uint, cb func()) { _m(tag, cb) }
+
+func _m(tag_remainder uint, cb func()) {
+	if tag_remainder == 0 {
+		cb()
+	} else {
+		mark_lookup[tag_remainder&0xf](tag_remainder>>bitWidth, cb)
+	}
+}
+
+func readStackTag() (tag uint, ok bool) {
+	var current_tag uint
+	offset := 0
+	for {
+		// the expectation with getStack is that it will either:
+		//  * return everything when offset is 0 and ignore stackBatchSize,
+		//    otherwise returning nothing when offset is not 0 (the gopherjs case)
+		//  * or it will return at most stackBatchSize, respect offset, and
+		//    shouldn't be called when it returns less than stackBatchSize
+		//    (the runtime.Callers case).
+		batch := getStack(offset, stackBatchSize)
+		for _, pc := range batch {
+			val, ok := pc_lookup[pc]
+			if !ok {
+				continue
+			}
+			if val < 0 {
+				return current_tag, true
+			}
+			current_tag <<= bitWidth
+			current_tag += uint(val)
+		}
+		if len(batch) < stackBatchSize {
+			break
+		}
+		offset += len(batch)
+	}
+	return 0, false
+}

--- a/vendor/github.com/jtolds/gls/stack_tags_js.go
+++ b/vendor/github.com/jtolds/gls/stack_tags_js.go
@@ -1,0 +1,75 @@
+// +build js
+
+package gls
+
+// This file is used for GopherJS builds, which don't have normal runtime
+// stack trace support
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/gopherjs/gopherjs/js"
+)
+
+const (
+	jsFuncNamePrefix = "github_com_jtolds_gls_mark"
+)
+
+func jsMarkStack() (f []uintptr) {
+	lines := strings.Split(
+		js.Global.Get("Error").New().Get("stack").String(), "\n")
+	f = make([]uintptr, 0, len(lines))
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if i == 0 {
+			if line != "Error" {
+				panic("didn't understand js stack trace")
+			}
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != "at" {
+			panic("didn't understand js stack trace")
+		}
+
+		pos := strings.Index(fields[1], jsFuncNamePrefix)
+		if pos < 0 {
+			continue
+		}
+		pos += len(jsFuncNamePrefix)
+		if pos >= len(fields[1]) {
+			panic("didn't understand js stack trace")
+		}
+		char := string(fields[1][pos])
+		switch char {
+		case "S":
+			f = append(f, uintptr(0))
+		default:
+			val, err := strconv.ParseUint(char, 16, 8)
+			if err != nil {
+				panic("didn't understand js stack trace")
+			}
+			f = append(f, uintptr(val)+1)
+		}
+	}
+	return f
+}
+
+func findPtr() uintptr {
+	funcs := jsMarkStack()
+	if len(funcs) == 0 {
+		panic("failed to find function pointer")
+	}
+	return funcs[0]
+}
+
+func getStack(offset, amount int) []uintptr {
+	if offset != 0 {
+		return nil
+	}
+	return jsMarkStack()
+}

--- a/vendor/github.com/jtolds/gls/stack_tags_main.go
+++ b/vendor/github.com/jtolds/gls/stack_tags_main.go
@@ -1,0 +1,23 @@
+// +build !js
+
+package gls
+
+// This file is used for standard Go builds, which have the expected runtime
+// support
+
+import (
+	"runtime"
+)
+
+func getStack(offset, amount int) []uintptr {
+	stack := make([]uintptr, amount)
+	return stack[:runtime.Callers(offset, stack)]
+}
+
+func findPtr() uintptr {
+	pc, _, _, ok := runtime.Caller(3)
+	if !ok {
+		panic("failed to find function pointer")
+	}
+	return pc
+}

--- a/vendor/github.com/smartystreets/assertions/CONTRIBUTING.md
+++ b/vendor/github.com/smartystreets/assertions/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+In general, the code posted to the [SmartyStreets github organization](https://github.com/smartystreets) is created to solve specific problems at SmartyStreets that are ancillary to our core products in the address verification industry and may or may not be useful to other organizations or developers. Our reason for posting said code isn't necessarily to solicit feedback or contributions from the community but more as a showcase of some of the approaches to solving problems we have adopted.
+
+Having stated that, we do consider issues raised by other githubbers as well as contributions submitted via pull requests. When submitting such a pull request, please follow these guidelines:
+
+- _Look before you leap:_ If the changes you plan to make are significant, it's in everyone's best interest for you to discuss them with a SmartyStreets team member prior to opening a pull request.
+- _License and ownership:_ If modifying the `LICENSE.md` file, limit your changes to fixing typographical mistakes. Do NOT modify the actual terms in the license or the copyright by **SmartyStreets, LLC**. Code submitted to SmartyStreets projects becomes property of SmartyStreets and must be compatible with the associated license.
+- _Testing:_ If the code you are submitting resides in packages/modules covered by automated tests, be sure to add passing tests that cover your changes and assert expected behavior and state. Submit the additional test cases as part of your change set.
+- _Style:_ Match your approach to **naming** and **formatting** with the surrounding code. Basically, the code you submit shouldn't stand out.
+  - "Naming" refers to such constructs as variables, methods, functions, classes, structs, interfaces, packages, modules, directories, files, etc...
+  - "Formatting" refers to such constructs as whitespace, horizontal line length, vertical function length, vertical file length, indentation, curly braces, etc...

--- a/vendor/github.com/smartystreets/assertions/LICENSE.md
+++ b/vendor/github.com/smartystreets/assertions/LICENSE.md
@@ -1,0 +1,23 @@
+Copyright (c) 2016 SmartyStreets, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the "Software"), to deal 
+in the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is 
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.
+
+NOTE: Various optional and subordinate components carry their own licensing
+requirements and restrictions.  Use of those components is subject to the terms
+and conditions outlined the respective license of each component.

--- a/vendor/github.com/smartystreets/assertions/README.md
+++ b/vendor/github.com/smartystreets/assertions/README.md
@@ -1,0 +1,575 @@
+# assertions
+--
+    import "github.com/smartystreets/assertions"
+
+Package assertions contains the implementations for all assertions which are
+referenced in goconvey's `convey` package
+(github.com/smartystreets/goconvey/convey) and gunit
+(github.com/smartystreets/gunit) for use with the So(...) method. They can also
+be used in traditional Go test functions and even in applications.
+
+Many of the assertions lean heavily on work done by Aaron Jacobs in his
+excellent oglematchers library. (https://github.com/jacobsa/oglematchers) The
+ShouldResemble assertion leans heavily on work done by Daniel Jacques in his
+very helpful go-render library. (https://github.com/luci/go-render)
+
+## Usage
+
+#### func  GoConveyMode
+
+```go
+func GoConveyMode(yes bool)
+```
+GoConveyMode provides control over JSON serialization of failures. When using
+the assertions in this package from the convey package JSON results are very
+helpful and can be rendered in a DIFF view. In that case, this function will be
+called with a true value to enable the JSON serialization. By default, the
+assertions in this package will not serializer a JSON result, making standalone
+ussage more convenient.
+
+#### func  ShouldAlmostEqual
+
+```go
+func ShouldAlmostEqual(actual interface{}, expected ...interface{}) string
+```
+ShouldAlmostEqual makes sure that two parameters are close enough to being
+equal. The acceptable delta may be specified with a third argument, or a very
+small default delta will be used.
+
+#### func  ShouldBeBetween
+
+```go
+func ShouldBeBetween(actual interface{}, expected ...interface{}) string
+```
+ShouldBeBetween receives exactly three parameters: an actual value, a lower
+bound, and an upper bound. It ensures that the actual value is between both
+bounds (but not equal to either of them).
+
+#### func  ShouldBeBetweenOrEqual
+
+```go
+func ShouldBeBetweenOrEqual(actual interface{}, expected ...interface{}) string
+```
+ShouldBeBetweenOrEqual receives exactly three parameters: an actual value, a
+lower bound, and an upper bound. It ensures that the actual value is between
+both bounds or equal to one of them.
+
+#### func  ShouldBeBlank
+
+```go
+func ShouldBeBlank(actual interface{}, expected ...interface{}) string
+```
+ShouldBeBlank receives exactly 1 string parameter and ensures that it is equal
+to "".
+
+#### func  ShouldBeChronological
+
+```go
+func ShouldBeChronological(actual interface{}, expected ...interface{}) string
+```
+ShouldBeChronological receives a []time.Time slice and asserts that the are in
+chronological order starting with the first time.Time as the earliest.
+
+#### func  ShouldBeEmpty
+
+```go
+func ShouldBeEmpty(actual interface{}, expected ...interface{}) string
+```
+ShouldBeEmpty receives a single parameter (actual) and determines whether or not
+calling len(actual) would return `0`. It obeys the rules specified by the len
+function for determining length: http://golang.org/pkg/builtin/#len
+
+#### func  ShouldBeFalse
+
+```go
+func ShouldBeFalse(actual interface{}, expected ...interface{}) string
+```
+ShouldBeFalse receives a single parameter and ensures that it is false.
+
+#### func  ShouldBeGreaterThan
+
+```go
+func ShouldBeGreaterThan(actual interface{}, expected ...interface{}) string
+```
+ShouldBeGreaterThan receives exactly two parameters and ensures that the first
+is greater than the second.
+
+#### func  ShouldBeGreaterThanOrEqualTo
+
+```go
+func ShouldBeGreaterThanOrEqualTo(actual interface{}, expected ...interface{}) string
+```
+ShouldBeGreaterThanOrEqualTo receives exactly two parameters and ensures that
+the first is greater than or equal to the second.
+
+#### func  ShouldBeIn
+
+```go
+func ShouldBeIn(actual interface{}, expected ...interface{}) string
+```
+ShouldBeIn receives at least 2 parameters. The first is a proposed member of the
+collection that is passed in either as the second parameter, or of the
+collection that is comprised of all the remaining parameters. This assertion
+ensures that the proposed member is in the collection (using ShouldEqual).
+
+#### func  ShouldBeLessThan
+
+```go
+func ShouldBeLessThan(actual interface{}, expected ...interface{}) string
+```
+ShouldBeLessThan receives exactly two parameters and ensures that the first is
+less than the second.
+
+#### func  ShouldBeLessThanOrEqualTo
+
+```go
+func ShouldBeLessThanOrEqualTo(actual interface{}, expected ...interface{}) string
+```
+ShouldBeLessThan receives exactly two parameters and ensures that the first is
+less than or equal to the second.
+
+#### func  ShouldBeNil
+
+```go
+func ShouldBeNil(actual interface{}, expected ...interface{}) string
+```
+ShouldBeNil receives a single parameter and ensures that it is nil.
+
+#### func  ShouldBeTrue
+
+```go
+func ShouldBeTrue(actual interface{}, expected ...interface{}) string
+```
+ShouldBeTrue receives a single parameter and ensures that it is true.
+
+#### func  ShouldBeZeroValue
+
+```go
+func ShouldBeZeroValue(actual interface{}, expected ...interface{}) string
+```
+ShouldBeZeroValue receives a single parameter and ensures that it is the Go
+equivalent of the default value, or "zero" value.
+
+#### func  ShouldContain
+
+```go
+func ShouldContain(actual interface{}, expected ...interface{}) string
+```
+ShouldContain receives exactly two parameters. The first is a slice and the
+second is a proposed member. Membership is determined using ShouldEqual.
+
+#### func  ShouldContainKey
+
+```go
+func ShouldContainKey(actual interface{}, expected ...interface{}) string
+```
+ShouldContainKey receives exactly two parameters. The first is a map and the
+second is a proposed key. Keys are compared with a simple '=='.
+
+#### func  ShouldContainSubstring
+
+```go
+func ShouldContainSubstring(actual interface{}, expected ...interface{}) string
+```
+ShouldContainSubstring receives exactly 2 string parameters and ensures that the
+first contains the second as a substring.
+
+#### func  ShouldEndWith
+
+```go
+func ShouldEndWith(actual interface{}, expected ...interface{}) string
+```
+ShouldEndWith receives exactly 2 string parameters and ensures that the first
+ends with the second.
+
+#### func  ShouldEqual
+
+```go
+func ShouldEqual(actual interface{}, expected ...interface{}) string
+```
+ShouldEqual receives exactly two parameters and does an equality check.
+
+#### func  ShouldEqualTrimSpace
+
+```go
+func ShouldEqualTrimSpace(actual interface{}, expected ...interface{}) string
+```
+ShouldEqualTrimSpace receives exactly 2 string parameters and ensures that the
+first is equal to the second after removing all leading and trailing whitespace
+using strings.TrimSpace(first).
+
+#### func  ShouldEqualWithout
+
+```go
+func ShouldEqualWithout(actual interface{}, expected ...interface{}) string
+```
+ShouldEqualWithout receives exactly 3 string parameters and ensures that the
+first is equal to the second after removing all instances of the third from the
+first using strings.Replace(first, third, "", -1).
+
+#### func  ShouldHappenAfter
+
+```go
+func ShouldHappenAfter(actual interface{}, expected ...interface{}) string
+```
+ShouldHappenAfter receives exactly 2 time.Time arguments and asserts that the
+first happens after the second.
+
+#### func  ShouldHappenBefore
+
+```go
+func ShouldHappenBefore(actual interface{}, expected ...interface{}) string
+```
+ShouldHappenBefore receives exactly 2 time.Time arguments and asserts that the
+first happens before the second.
+
+#### func  ShouldHappenBetween
+
+```go
+func ShouldHappenBetween(actual interface{}, expected ...interface{}) string
+```
+ShouldHappenBetween receives exactly 3 time.Time arguments and asserts that the
+first happens between (not on) the second and third.
+
+#### func  ShouldHappenOnOrAfter
+
+```go
+func ShouldHappenOnOrAfter(actual interface{}, expected ...interface{}) string
+```
+ShouldHappenOnOrAfter receives exactly 2 time.Time arguments and asserts that
+the first happens on or after the second.
+
+#### func  ShouldHappenOnOrBefore
+
+```go
+func ShouldHappenOnOrBefore(actual interface{}, expected ...interface{}) string
+```
+ShouldHappenOnOrBefore receives exactly 2 time.Time arguments and asserts that
+the first happens on or before the second.
+
+#### func  ShouldHappenOnOrBetween
+
+```go
+func ShouldHappenOnOrBetween(actual interface{}, expected ...interface{}) string
+```
+ShouldHappenOnOrBetween receives exactly 3 time.Time arguments and asserts that
+the first happens between or on the second and third.
+
+#### func  ShouldHappenWithin
+
+```go
+func ShouldHappenWithin(actual interface{}, expected ...interface{}) string
+```
+ShouldHappenWithin receives a time.Time, a time.Duration, and a time.Time (3
+arguments) and asserts that the first time.Time happens within or on the
+duration specified relative to the other time.Time.
+
+#### func  ShouldHaveLength
+
+```go
+func ShouldHaveLength(actual interface{}, expected ...interface{}) string
+```
+ShouldHaveLength receives 2 parameters. The first is a collection to check the
+length of, the second being the expected length. It obeys the rules specified by
+the len function for determining length: http://golang.org/pkg/builtin/#len
+
+#### func  ShouldHaveSameTypeAs
+
+```go
+func ShouldHaveSameTypeAs(actual interface{}, expected ...interface{}) string
+```
+ShouldHaveSameTypeAs receives exactly two parameters and compares their
+underlying types for equality.
+
+#### func  ShouldImplement
+
+```go
+func ShouldImplement(actual interface{}, expectedList ...interface{}) string
+```
+ShouldImplement receives exactly two parameters and ensures that the first
+implements the interface type of the second.
+
+#### func  ShouldNotAlmostEqual
+
+```go
+func ShouldNotAlmostEqual(actual interface{}, expected ...interface{}) string
+```
+ShouldNotAlmostEqual is the inverse of ShouldAlmostEqual
+
+#### func  ShouldNotBeBetween
+
+```go
+func ShouldNotBeBetween(actual interface{}, expected ...interface{}) string
+```
+ShouldNotBeBetween receives exactly three parameters: an actual value, a lower
+bound, and an upper bound. It ensures that the actual value is NOT between both
+bounds.
+
+#### func  ShouldNotBeBetweenOrEqual
+
+```go
+func ShouldNotBeBetweenOrEqual(actual interface{}, expected ...interface{}) string
+```
+ShouldNotBeBetweenOrEqual receives exactly three parameters: an actual value, a
+lower bound, and an upper bound. It ensures that the actual value is nopt
+between the bounds nor equal to either of them.
+
+#### func  ShouldNotBeBlank
+
+```go
+func ShouldNotBeBlank(actual interface{}, expected ...interface{}) string
+```
+ShouldNotBeBlank receives exactly 1 string parameter and ensures that it is
+equal to "".
+
+#### func  ShouldNotBeEmpty
+
+```go
+func ShouldNotBeEmpty(actual interface{}, expected ...interface{}) string
+```
+ShouldNotBeEmpty receives a single parameter (actual) and determines whether or
+not calling len(actual) would return a value greater than zero. It obeys the
+rules specified by the `len` function for determining length:
+http://golang.org/pkg/builtin/#len
+
+#### func  ShouldNotBeIn
+
+```go
+func ShouldNotBeIn(actual interface{}, expected ...interface{}) string
+```
+ShouldNotBeIn receives at least 2 parameters. The first is a proposed member of
+the collection that is passed in either as the second parameter, or of the
+collection that is comprised of all the remaining parameters. This assertion
+ensures that the proposed member is NOT in the collection (using ShouldEqual).
+
+#### func  ShouldNotBeNil
+
+```go
+func ShouldNotBeNil(actual interface{}, expected ...interface{}) string
+```
+ShouldNotBeNil receives a single parameter and ensures that it is not nil.
+
+#### func  ShouldNotContain
+
+```go
+func ShouldNotContain(actual interface{}, expected ...interface{}) string
+```
+ShouldNotContain receives exactly two parameters. The first is a slice and the
+second is a proposed member. Membership is determinied using ShouldEqual.
+
+#### func  ShouldNotContainKey
+
+```go
+func ShouldNotContainKey(actual interface{}, expected ...interface{}) string
+```
+ShouldNotContainKey receives exactly two parameters. The first is a map and the
+second is a proposed absent key. Keys are compared with a simple '=='.
+
+#### func  ShouldNotContainSubstring
+
+```go
+func ShouldNotContainSubstring(actual interface{}, expected ...interface{}) string
+```
+ShouldNotContainSubstring receives exactly 2 string parameters and ensures that
+the first does NOT contain the second as a substring.
+
+#### func  ShouldNotEndWith
+
+```go
+func ShouldNotEndWith(actual interface{}, expected ...interface{}) string
+```
+ShouldEndWith receives exactly 2 string parameters and ensures that the first
+does not end with the second.
+
+#### func  ShouldNotEqual
+
+```go
+func ShouldNotEqual(actual interface{}, expected ...interface{}) string
+```
+ShouldNotEqual receives exactly two parameters and does an inequality check.
+
+#### func  ShouldNotHappenOnOrBetween
+
+```go
+func ShouldNotHappenOnOrBetween(actual interface{}, expected ...interface{}) string
+```
+ShouldNotHappenOnOrBetween receives exactly 3 time.Time arguments and asserts
+that the first does NOT happen between or on the second or third.
+
+#### func  ShouldNotHappenWithin
+
+```go
+func ShouldNotHappenWithin(actual interface{}, expected ...interface{}) string
+```
+ShouldNotHappenWithin receives a time.Time, a time.Duration, and a time.Time (3
+arguments) and asserts that the first time.Time does NOT happen within or on the
+duration specified relative to the other time.Time.
+
+#### func  ShouldNotHaveSameTypeAs
+
+```go
+func ShouldNotHaveSameTypeAs(actual interface{}, expected ...interface{}) string
+```
+ShouldNotHaveSameTypeAs receives exactly two parameters and compares their
+underlying types for inequality.
+
+#### func  ShouldNotImplement
+
+```go
+func ShouldNotImplement(actual interface{}, expectedList ...interface{}) string
+```
+ShouldNotImplement receives exactly two parameters and ensures that the first
+does NOT implement the interface type of the second.
+
+#### func  ShouldNotPanic
+
+```go
+func ShouldNotPanic(actual interface{}, expected ...interface{}) (message string)
+```
+ShouldNotPanic receives a void, niladic function and expects to execute the
+function without any panic.
+
+#### func  ShouldNotPanicWith
+
+```go
+func ShouldNotPanicWith(actual interface{}, expected ...interface{}) (message string)
+```
+ShouldNotPanicWith receives a void, niladic function and expects to recover a
+panic whose content differs from the second argument.
+
+#### func  ShouldNotPointTo
+
+```go
+func ShouldNotPointTo(actual interface{}, expected ...interface{}) string
+```
+ShouldNotPointTo receives exactly two parameters and checks to see that they
+point to different addresess.
+
+#### func  ShouldNotResemble
+
+```go
+func ShouldNotResemble(actual interface{}, expected ...interface{}) string
+```
+ShouldNotResemble receives exactly two parameters and does an inverse deep equal
+check (see reflect.DeepEqual)
+
+#### func  ShouldNotStartWith
+
+```go
+func ShouldNotStartWith(actual interface{}, expected ...interface{}) string
+```
+ShouldNotStartWith receives exactly 2 string parameters and ensures that the
+first does not start with the second.
+
+#### func  ShouldPanic
+
+```go
+func ShouldPanic(actual interface{}, expected ...interface{}) (message string)
+```
+ShouldPanic receives a void, niladic function and expects to recover a panic.
+
+#### func  ShouldPanicWith
+
+```go
+func ShouldPanicWith(actual interface{}, expected ...interface{}) (message string)
+```
+ShouldPanicWith receives a void, niladic function and expects to recover a panic
+with the second argument as the content.
+
+#### func  ShouldPointTo
+
+```go
+func ShouldPointTo(actual interface{}, expected ...interface{}) string
+```
+ShouldPointTo receives exactly two parameters and checks to see that they point
+to the same address.
+
+#### func  ShouldResemble
+
+```go
+func ShouldResemble(actual interface{}, expected ...interface{}) string
+```
+ShouldResemble receives exactly two parameters and does a deep equal check (see
+reflect.DeepEqual)
+
+#### func  ShouldStartWith
+
+```go
+func ShouldStartWith(actual interface{}, expected ...interface{}) string
+```
+ShouldStartWith receives exactly 2 string parameters and ensures that the first
+starts with the second.
+
+#### func  So
+
+```go
+func So(actual interface{}, assert assertion, expected ...interface{}) (bool, string)
+```
+So is a convenience function (as opposed to an inconvenience function?) for
+running assertions on arbitrary arguments in any context, be it for testing or
+even application logging. It allows you to perform assertion-like behavior (and
+get nicely formatted messages detailing discrepancies) but without the program
+blowing up or panicking. All that is required is to import this package and call
+`So` with one of the assertions exported by this package as the second
+parameter. The first return parameter is a boolean indicating if the assertion
+was true. The second return parameter is the well-formatted message showing why
+an assertion was incorrect, or blank if the assertion was correct.
+
+Example:
+
+    if ok, message := So(x, ShouldBeGreaterThan, y); !ok {
+         log.Println(message)
+    }
+
+#### type Assertion
+
+```go
+type Assertion struct {
+}
+```
+
+
+#### func  New
+
+```go
+func New(t testingT) *Assertion
+```
+New swallows the *testing.T struct and prints failed assertions using t.Error.
+Example: assertions.New(t).So(1, should.Equal, 1)
+
+#### func (*Assertion) Failed
+
+```go
+func (this *Assertion) Failed() bool
+```
+Failed reports whether any calls to So (on this Assertion instance) have failed.
+
+#### func (*Assertion) So
+
+```go
+func (this *Assertion) So(actual interface{}, assert assertion, expected ...interface{}) bool
+```
+So calls the standalone So function and additionally, calls t.Error in failure
+scenarios.
+
+#### type FailureView
+
+```go
+type FailureView struct {
+	Message  string `json:"Message"`
+	Expected string `json:"Expected"`
+	Actual   string `json:"Actual"`
+}
+```
+
+This struct is also declared in
+github.com/smartystreets/goconvey/convey/reporting. The json struct tags should
+be equal in both declarations.
+
+#### type Serializer
+
+```go
+type Serializer interface {
+	// contains filtered or unexported methods
+}
+```

--- a/vendor/github.com/smartystreets/assertions/collections.go
+++ b/vendor/github.com/smartystreets/assertions/collections.go
@@ -1,0 +1,244 @@
+package assertions
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/smartystreets/assertions/internal/oglematchers"
+)
+
+// ShouldContain receives exactly two parameters. The first is a slice and the
+// second is a proposed member. Membership is determined using ShouldEqual.
+func ShouldContain(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	if matchError := oglematchers.Contains(expected[0]).Matches(actual); matchError != nil {
+		typeName := reflect.TypeOf(actual)
+
+		if fmt.Sprintf("%v", matchError) == "which is not a slice or array" {
+			return fmt.Sprintf(shouldHaveBeenAValidCollection, typeName)
+		}
+		return fmt.Sprintf(shouldHaveContained, typeName, expected[0])
+	}
+	return success
+}
+
+// ShouldNotContain receives exactly two parameters. The first is a slice and the
+// second is a proposed member. Membership is determinied using ShouldEqual.
+func ShouldNotContain(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+	typeName := reflect.TypeOf(actual)
+
+	if matchError := oglematchers.Contains(expected[0]).Matches(actual); matchError != nil {
+		if fmt.Sprintf("%v", matchError) == "which is not a slice or array" {
+			return fmt.Sprintf(shouldHaveBeenAValidCollection, typeName)
+		}
+		return success
+	}
+	return fmt.Sprintf(shouldNotHaveContained, typeName, expected[0])
+}
+
+// ShouldContainKey receives exactly two parameters. The first is a map and the
+// second is a proposed key. Keys are compared with a simple '=='.
+func ShouldContainKey(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	keys, isMap := mapKeys(actual)
+	if !isMap {
+		return fmt.Sprintf(shouldHaveBeenAValidMap, reflect.TypeOf(actual))
+	}
+
+	if !keyFound(keys, expected[0]) {
+		return fmt.Sprintf(shouldHaveContainedKey, reflect.TypeOf(actual), expected)
+	}
+
+	return ""
+}
+
+// ShouldNotContainKey receives exactly two parameters. The first is a map and the
+// second is a proposed absent key. Keys are compared with a simple '=='.
+func ShouldNotContainKey(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	keys, isMap := mapKeys(actual)
+	if !isMap {
+		return fmt.Sprintf(shouldHaveBeenAValidMap, reflect.TypeOf(actual))
+	}
+
+	if keyFound(keys, expected[0]) {
+		return fmt.Sprintf(shouldNotHaveContainedKey, reflect.TypeOf(actual), expected)
+	}
+
+	return ""
+}
+
+func mapKeys(m interface{}) ([]reflect.Value, bool) {
+	value := reflect.ValueOf(m)
+	if value.Kind() != reflect.Map {
+		return nil, false
+	}
+	return value.MapKeys(), true
+}
+func keyFound(keys []reflect.Value, expectedKey interface{}) bool {
+	found := false
+	for _, key := range keys {
+		if key.Interface() == expectedKey {
+			found = true
+		}
+	}
+	return found
+}
+
+// ShouldBeIn receives at least 2 parameters. The first is a proposed member of the collection
+// that is passed in either as the second parameter, or of the collection that is comprised
+// of all the remaining parameters. This assertion ensures that the proposed member is in
+// the collection (using ShouldEqual).
+func ShouldBeIn(actual interface{}, expected ...interface{}) string {
+	if fail := atLeast(1, expected); fail != success {
+		return fail
+	}
+
+	if len(expected) == 1 {
+		return shouldBeIn(actual, expected[0])
+	}
+	return shouldBeIn(actual, expected)
+}
+func shouldBeIn(actual interface{}, expected interface{}) string {
+	if matchError := oglematchers.Contains(actual).Matches(expected); matchError != nil {
+		return fmt.Sprintf(shouldHaveBeenIn, actual, reflect.TypeOf(expected))
+	}
+	return success
+}
+
+// ShouldNotBeIn receives at least 2 parameters. The first is a proposed member of the collection
+// that is passed in either as the second parameter, or of the collection that is comprised
+// of all the remaining parameters. This assertion ensures that the proposed member is NOT in
+// the collection (using ShouldEqual).
+func ShouldNotBeIn(actual interface{}, expected ...interface{}) string {
+	if fail := atLeast(1, expected); fail != success {
+		return fail
+	}
+
+	if len(expected) == 1 {
+		return shouldNotBeIn(actual, expected[0])
+	}
+	return shouldNotBeIn(actual, expected)
+}
+func shouldNotBeIn(actual interface{}, expected interface{}) string {
+	if matchError := oglematchers.Contains(actual).Matches(expected); matchError == nil {
+		return fmt.Sprintf(shouldNotHaveBeenIn, actual, reflect.TypeOf(expected))
+	}
+	return success
+}
+
+// ShouldBeEmpty receives a single parameter (actual) and determines whether or not
+// calling len(actual) would return `0`. It obeys the rules specified by the len
+// function for determining length: http://golang.org/pkg/builtin/#len
+func ShouldBeEmpty(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	}
+
+	if actual == nil {
+		return success
+	}
+
+	value := reflect.ValueOf(actual)
+	switch value.Kind() {
+	case reflect.Slice:
+		if value.Len() == 0 {
+			return success
+		}
+	case reflect.Chan:
+		if value.Len() == 0 {
+			return success
+		}
+	case reflect.Map:
+		if value.Len() == 0 {
+			return success
+		}
+	case reflect.String:
+		if value.Len() == 0 {
+			return success
+		}
+	case reflect.Ptr:
+		elem := value.Elem()
+		kind := elem.Kind()
+		if (kind == reflect.Slice || kind == reflect.Array) && elem.Len() == 0 {
+			return success
+		}
+	}
+
+	return fmt.Sprintf(shouldHaveBeenEmpty, actual)
+}
+
+// ShouldNotBeEmpty receives a single parameter (actual) and determines whether or not
+// calling len(actual) would return a value greater than zero. It obeys the rules
+// specified by the `len` function for determining length: http://golang.org/pkg/builtin/#len
+func ShouldNotBeEmpty(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	}
+
+	if empty := ShouldBeEmpty(actual, expected...); empty != success {
+		return success
+	}
+	return fmt.Sprintf(shouldNotHaveBeenEmpty, actual)
+}
+
+// ShouldHaveLength receives 2 parameters. The first is a collection to check
+// the length of, the second being the expected length. It obeys the rules
+// specified by the len function for determining length:
+// http://golang.org/pkg/builtin/#len
+func ShouldHaveLength(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	var expectedLen int64
+	lenValue := reflect.ValueOf(expected[0])
+	switch lenValue.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		expectedLen = lenValue.Int()
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		expectedLen = int64(lenValue.Uint())
+	default:
+		return fmt.Sprintf(shouldHaveBeenAValidInteger, reflect.TypeOf(expected[0]))
+	}
+
+	if expectedLen < 0 {
+		return fmt.Sprintf(shouldHaveBeenAValidLength, expected[0])
+	}
+
+	value := reflect.ValueOf(actual)
+	switch value.Kind() {
+	case reflect.Slice,
+		reflect.Chan,
+		reflect.Map,
+		reflect.String:
+		if int64(value.Len()) == expectedLen {
+			return success
+		} else {
+			return fmt.Sprintf(shouldHaveHadLength, actual, value.Len(), expectedLen)
+		}
+	case reflect.Ptr:
+		elem := value.Elem()
+		kind := elem.Kind()
+		if kind == reflect.Slice || kind == reflect.Array {
+			if int64(elem.Len()) == expectedLen {
+				return success
+			} else {
+				return fmt.Sprintf(shouldHaveHadLength, actual, elem.Len(), expectedLen)
+			}
+		}
+	}
+	return fmt.Sprintf(shouldHaveBeenAValidCollection, reflect.TypeOf(actual))
+}

--- a/vendor/github.com/smartystreets/assertions/collections_test.go
+++ b/vendor/github.com/smartystreets/assertions/collections_test.go
@@ -1,0 +1,171 @@
+package assertions
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestShouldContainKey(t *testing.T) {
+	fail(t, so(map[int]int{}, ShouldContainKey), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(map[int]int{}, ShouldContainKey, 1, 2, 3), "This assertion requires exactly 1 comparison values (you provided 3).")
+
+	fail(t, so(Thing1{}, ShouldContainKey, 1), "You must provide a valid map type (was assertions.Thing1)!")
+	fail(t, so(nil, ShouldContainKey, 1), "You must provide a valid map type (was <nil>)!")
+	fail(t, so(map[int]int{1: 41}, ShouldContainKey, 2), "Expected the map[int]int to contain the key: [2] (but it didn't)!")
+
+	pass(t, so(map[int]int{1: 41}, ShouldContainKey, 1))
+	pass(t, so(map[int]int{1: 41, 2: 42, 3: 43}, ShouldContainKey, 2))
+}
+
+func TestShouldNotContainKey(t *testing.T) {
+	fail(t, so(map[int]int{}, ShouldNotContainKey), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(map[int]int{}, ShouldNotContainKey, 1, 2, 3), "This assertion requires exactly 1 comparison values (you provided 3).")
+
+	fail(t, so(Thing1{}, ShouldNotContainKey, 1), "You must provide a valid map type (was assertions.Thing1)!")
+	fail(t, so(nil, ShouldNotContainKey, 1), "You must provide a valid map type (was <nil>)!")
+	fail(t, so(map[int]int{1: 41}, ShouldNotContainKey, 1), "Expected the map[int]int NOT to contain the key: [1] (but it did)!")
+	pass(t, so(map[int]int{1: 41}, ShouldNotContainKey, 2))
+}
+
+func TestShouldContain(t *testing.T) {
+	fail(t, so([]int{}, ShouldContain), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so([]int{}, ShouldContain, 1, 2, 3), "This assertion requires exactly 1 comparison values (you provided 3).")
+
+	fail(t, so(Thing1{}, ShouldContain, 1), "You must provide a valid container (was assertions.Thing1)!")
+	fail(t, so(nil, ShouldContain, 1), "You must provide a valid container (was <nil>)!")
+	fail(t, so([]int{1}, ShouldContain, 2), "Expected the container ([]int) to contain: '2' (but it didn't)!")
+	fail(t, so([][]int{[]int{1}}, ShouldContain, []int{2}), "Expected the container ([][]int) to contain: '[2]' (but it didn't)!")
+
+	pass(t, so([]int{1}, ShouldContain, 1))
+	pass(t, so([]int{1, 2, 3}, ShouldContain, 2))
+	pass(t, so([][]int{[]int{1}, []int{2}, []int{3}}, ShouldContain, []int{2}))
+}
+
+func TestShouldNotContain(t *testing.T) {
+	fail(t, so([]int{}, ShouldNotContain), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so([]int{}, ShouldNotContain, 1, 2, 3), "This assertion requires exactly 1 comparison values (you provided 3).")
+
+	fail(t, so(Thing1{}, ShouldNotContain, 1), "You must provide a valid container (was assertions.Thing1)!")
+	fail(t, so(nil, ShouldNotContain, 1), "You must provide a valid container (was <nil>)!")
+
+	fail(t, so([]int{1}, ShouldNotContain, 1), "Expected the container ([]int) NOT to contain: '1' (but it did)!")
+	fail(t, so([]int{1, 2, 3}, ShouldNotContain, 2), "Expected the container ([]int) NOT to contain: '2' (but it did)!")
+	fail(t, so([][]int{[]int{1}, []int{2}, []int{3}}, ShouldNotContain, []int{2}), "Expected the container ([][]int) NOT to contain: '[2]' (but it did)!")
+
+	pass(t, so([]int{1}, ShouldNotContain, 2))
+	pass(t, so([][]int{[]int{1}, []int{2}, []int{3}}, ShouldNotContain, []int{4}))
+}
+
+func TestShouldBeIn(t *testing.T) {
+	fail(t, so(4, ShouldBeIn), needNonEmptyCollection)
+
+	container := []int{1, 2, 3, 4}
+	pass(t, so(4, ShouldBeIn, container))
+	pass(t, so(4, ShouldBeIn, 1, 2, 3, 4))
+	pass(t, so([]int{4}, ShouldBeIn, [][]int{[]int{1}, []int{2}, []int{3}, []int{4}}))
+	pass(t, so([]int{4}, ShouldBeIn, []int{1}, []int{2}, []int{3}, []int{4}))
+
+	fail(t, so(4, ShouldBeIn, 1, 2, 3), "Expected '4' to be in the container ([]interface {}), but it wasn't!")
+	fail(t, so(4, ShouldBeIn, []int{1, 2, 3}), "Expected '4' to be in the container ([]int), but it wasn't!")
+	fail(t, so([]int{4}, ShouldBeIn, []int{1}, []int{2}, []int{3}), "Expected '[4]' to be in the container ([]interface {}), but it wasn't!")
+	fail(t, so([]int{4}, ShouldBeIn, [][]int{[]int{1}, []int{2}, []int{3}}), "Expected '[4]' to be in the container ([][]int), but it wasn't!")
+}
+
+func TestShouldNotBeIn(t *testing.T) {
+	fail(t, so(4, ShouldNotBeIn), needNonEmptyCollection)
+
+	container := []int{1, 2, 3, 4}
+	pass(t, so(42, ShouldNotBeIn, container))
+	pass(t, so(42, ShouldNotBeIn, 1, 2, 3, 4))
+	pass(t, so([]int{42}, ShouldNotBeIn, []int{1}, []int{2}, []int{3}, []int{4}))
+	pass(t, so([]int{42}, ShouldNotBeIn, [][]int{[]int{1}, []int{2}, []int{3}, []int{4}}))
+
+	fail(t, so(2, ShouldNotBeIn, 1, 2, 3), "Expected '2' NOT to be in the container ([]interface {}), but it was!")
+	fail(t, so(2, ShouldNotBeIn, []int{1, 2, 3}), "Expected '2' NOT to be in the container ([]int), but it was!")
+	fail(t, so([]int{2}, ShouldNotBeIn, []int{1}, []int{2}, []int{3}), "Expected '[2]' NOT to be in the container ([]interface {}), but it was!")
+	fail(t, so([]int{2}, ShouldNotBeIn, [][]int{[]int{1}, []int{2}, []int{3}}), "Expected '[2]' NOT to be in the container ([][]int), but it was!")
+}
+
+func TestShouldBeEmpty(t *testing.T) {
+	fail(t, so(1, ShouldBeEmpty, 2, 3), "This assertion requires exactly 0 comparison values (you provided 2).")
+
+	pass(t, so([]int{}, ShouldBeEmpty))           // empty slice
+	pass(t, so([][]int{}, ShouldBeEmpty))         // empty slice
+	pass(t, so([]interface{}{}, ShouldBeEmpty))   // empty slice
+	pass(t, so(map[string]int{}, ShouldBeEmpty))  // empty map
+	pass(t, so("", ShouldBeEmpty))                // empty string
+	pass(t, so(&[]int{}, ShouldBeEmpty))          // pointer to empty slice
+	pass(t, so(&[0]int{}, ShouldBeEmpty))         // pointer to empty array
+	pass(t, so(nil, ShouldBeEmpty))               // nil
+	pass(t, so(make(chan string), ShouldBeEmpty)) // empty channel
+
+	fail(t, so([]int{1}, ShouldBeEmpty), "Expected [1] to be empty (but it wasn't)!")                      // non-empty slice
+	fail(t, so([][]int{[]int{1}}, ShouldBeEmpty), "Expected [[1]] to be empty (but it wasn't)!")           // non-empty slice
+	fail(t, so([]interface{}{1}, ShouldBeEmpty), "Expected [1] to be empty (but it wasn't)!")              // non-empty slice
+	fail(t, so(map[string]int{"hi": 0}, ShouldBeEmpty), "Expected map[hi:0] to be empty (but it wasn't)!") // non-empty map
+	fail(t, so("hi", ShouldBeEmpty), "Expected hi to be empty (but it wasn't)!")                           // non-empty string
+	fail(t, so(&[]int{1}, ShouldBeEmpty), "Expected &[1] to be empty (but it wasn't)!")                    // pointer to non-empty slice
+	fail(t, so(&[1]int{1}, ShouldBeEmpty), "Expected &[1] to be empty (but it wasn't)!")                   // pointer to non-empty array
+	c := make(chan int, 1)                                                                                 // non-empty channel
+	go func() { c <- 1 }()
+	time.Sleep(time.Millisecond)
+	fail(t, so(c, ShouldBeEmpty), fmt.Sprintf("Expected %+v to be empty (but it wasn't)!", c))
+}
+
+func TestShouldNotBeEmpty(t *testing.T) {
+	fail(t, so(1, ShouldNotBeEmpty, 2, 3), "This assertion requires exactly 0 comparison values (you provided 2).")
+
+	fail(t, so([]int{}, ShouldNotBeEmpty), "Expected [] to NOT be empty (but it was)!")             // empty slice
+	fail(t, so([]interface{}{}, ShouldNotBeEmpty), "Expected [] to NOT be empty (but it was)!")     // empty slice
+	fail(t, so(map[string]int{}, ShouldNotBeEmpty), "Expected map[] to NOT be empty (but it was)!") // empty map
+	fail(t, so("", ShouldNotBeEmpty), "Expected  to NOT be empty (but it was)!")                    // empty string
+	fail(t, so(&[]int{}, ShouldNotBeEmpty), "Expected &[] to NOT be empty (but it was)!")           // pointer to empty slice
+	fail(t, so(&[0]int{}, ShouldNotBeEmpty), "Expected &[] to NOT be empty (but it was)!")          // pointer to empty array
+	fail(t, so(nil, ShouldNotBeEmpty), "Expected <nil> to NOT be empty (but it was)!")              // nil
+	c := make(chan int, 0)                                                                          // non-empty channel
+	fail(t, so(c, ShouldNotBeEmpty), fmt.Sprintf("Expected %+v to NOT be empty (but it was)!", c))  // empty channel
+
+	pass(t, so([]int{1}, ShouldNotBeEmpty))                // non-empty slice
+	pass(t, so([]interface{}{1}, ShouldNotBeEmpty))        // non-empty slice
+	pass(t, so(map[string]int{"hi": 0}, ShouldNotBeEmpty)) // non-empty map
+	pass(t, so("hi", ShouldNotBeEmpty))                    // non-empty string
+	pass(t, so(&[]int{1}, ShouldNotBeEmpty))               // pointer to non-empty slice
+	pass(t, so(&[1]int{1}, ShouldNotBeEmpty))              // pointer to non-empty array
+	c = make(chan int, 1)
+	go func() { c <- 1 }()
+	time.Sleep(time.Millisecond)
+	pass(t, so(c, ShouldNotBeEmpty))
+}
+
+func TestShouldHaveLength(t *testing.T) {
+	fail(t, so(1, ShouldHaveLength, 2), "You must provide a valid container (was int)!")
+	fail(t, so(nil, ShouldHaveLength, 1), "You must provide a valid container (was <nil>)!")
+	fail(t, so("hi", ShouldHaveLength, float64(1.0)), "You must provide a valid integer (was float64)!")
+	fail(t, so([]string{}, ShouldHaveLength), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so([]string{}, ShouldHaveLength, 1, 2), "This assertion requires exactly 1 comparison values (you provided 2).")
+	fail(t, so([]string{}, ShouldHaveLength, -10), "You must provide a valid positive integer (was -10)!")
+
+	fail(t, so([]int{}, ShouldHaveLength, 1), "Expected [] (length: 0) to have length equal to '1', but it wasn't!")             // empty slice
+	fail(t, so([]interface{}{}, ShouldHaveLength, 1), "Expected [] (length: 0) to have length equal to '1', but it wasn't!")     // empty slice
+	fail(t, so(map[string]int{}, ShouldHaveLength, 1), "Expected map[] (length: 0) to have length equal to '1', but it wasn't!") // empty map
+	fail(t, so("", ShouldHaveLength, 1), "Expected  (length: 0) to have length equal to '1', but it wasn't!")                    // empty string
+	fail(t, so(&[]int{}, ShouldHaveLength, 1), "Expected &[] (length: 0) to have length equal to '1', but it wasn't!")           // pointer to empty slice
+	fail(t, so(&[0]int{}, ShouldHaveLength, 1), "Expected &[] (length: 0) to have length equal to '1', but it wasn't!")          // pointer to empty array
+	c := make(chan int, 0)                                                                                                       // non-empty channel
+	fail(t, so(c, ShouldHaveLength, 1), fmt.Sprintf("Expected %+v (length: 0) to have length equal to '1', but it wasn't!", c))
+	c = make(chan int) // empty channel
+	fail(t, so(c, ShouldHaveLength, 1), fmt.Sprintf("Expected %+v (length: 0) to have length equal to '1', but it wasn't!", c))
+
+	pass(t, so([]int{1}, ShouldHaveLength, 1))                // non-empty slice
+	pass(t, so([]interface{}{1}, ShouldHaveLength, 1))        // non-empty slice
+	pass(t, so(map[string]int{"hi": 0}, ShouldHaveLength, 1)) // non-empty map
+	pass(t, so("hi", ShouldHaveLength, 2))                    // non-empty string
+	pass(t, so(&[]int{1}, ShouldHaveLength, 1))               // pointer to non-empty slice
+	pass(t, so(&[1]int{1}, ShouldHaveLength, 1))              // pointer to non-empty array
+	c = make(chan int, 1)
+	go func() { c <- 1 }()
+	time.Sleep(time.Millisecond)
+	pass(t, so(c, ShouldHaveLength, 1))
+
+}

--- a/vendor/github.com/smartystreets/assertions/doc.go
+++ b/vendor/github.com/smartystreets/assertions/doc.go
@@ -1,0 +1,105 @@
+// Package assertions contains the implementations for all assertions which
+// are referenced in goconvey's `convey` package
+// (github.com/smartystreets/goconvey/convey) and gunit (github.com/smartystreets/gunit)
+// for use with the So(...) method.
+// They can also be used in traditional Go test functions and even in
+// applications.
+//
+// Many of the assertions lean heavily on work done by Aaron Jacobs in his excellent oglematchers library.
+// (https://github.com/jacobsa/oglematchers)
+// The ShouldResemble assertion leans heavily on work done by Daniel Jacques in his very helpful go-render library.
+// (https://github.com/luci/go-render)
+package assertions
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// By default we use a no-op serializer. The actual Serializer provides a JSON
+// representation of failure results on selected assertions so the goconvey
+// web UI can display a convenient diff.
+var serializer Serializer = new(noopSerializer)
+
+// GoConveyMode provides control over JSON serialization of failures. When
+// using the assertions in this package from the convey package JSON results
+// are very helpful and can be rendered in a DIFF view. In that case, this function
+// will be called with a true value to enable the JSON serialization. By default,
+// the assertions in this package will not serializer a JSON result, making
+// standalone usage more convenient.
+func GoConveyMode(yes bool) {
+	if yes {
+		serializer = newSerializer()
+	} else {
+		serializer = new(noopSerializer)
+	}
+}
+
+type testingT interface {
+	Error(args ...interface{})
+}
+
+type Assertion struct {
+	t      testingT
+	failed bool
+}
+
+// New swallows the *testing.T struct and prints failed assertions using t.Error.
+// Example: assertions.New(t).So(1, should.Equal, 1)
+func New(t testingT) *Assertion {
+	return &Assertion{t: t}
+}
+
+// Failed reports whether any calls to So (on this Assertion instance) have failed.
+func (this *Assertion) Failed() bool {
+	return this.failed
+}
+
+// So calls the standalone So function and additionally, calls t.Error in failure scenarios.
+func (this *Assertion) So(actual interface{}, assert assertion, expected ...interface{}) bool {
+	ok, result := So(actual, assert, expected...)
+	if !ok {
+		this.failed = true
+		_, file, line, _ := runtime.Caller(1)
+		this.t.Error(fmt.Sprintf("\n%s:%d\n%s", file, line, result))
+	}
+	return ok
+}
+
+// So is a convenience function (as opposed to an inconvenience function?)
+// for running assertions on arbitrary arguments in any context, be it for testing or even
+// application logging. It allows you to perform assertion-like behavior (and get nicely
+// formatted messages detailing discrepancies) but without the program blowing up or panicking.
+// All that is required is to import this package and call `So` with one of the assertions
+// exported by this package as the second parameter.
+// The first return parameter is a boolean indicating if the assertion was true. The second
+// return parameter is the well-formatted message showing why an assertion was incorrect, or
+// blank if the assertion was correct.
+//
+// Example:
+//
+//   if ok, message := So(x, ShouldBeGreaterThan, y); !ok {
+//        log.Println(message)
+//   }
+//
+func So(actual interface{}, assert assertion, expected ...interface{}) (bool, string) {
+	if result := so(actual, assert, expected...); len(result) == 0 {
+		return true, result
+	} else {
+		return false, result
+	}
+}
+
+// so is like So, except that it only returns the string message, which is blank if the
+// assertion passed. Used to facilitate testing.
+func so(actual interface{}, assert func(interface{}, ...interface{}) string, expected ...interface{}) string {
+	return assert(actual, expected...)
+}
+
+// assertion is an alias for a function with a signature that the So()
+// function can handle. Any future or custom assertions should conform to this
+// method signature. The return value should be an empty string if the assertion
+// passes and a well-formed failure message if not.
+type assertion func(actual interface{}, expected ...interface{}) string
+
+////////////////////////////////////////////////////////////////////////////

--- a/vendor/github.com/smartystreets/assertions/doc_test.go
+++ b/vendor/github.com/smartystreets/assertions/doc_test.go
@@ -1,0 +1,57 @@
+package assertions
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestPassingAssertion(t *testing.T) {
+	fake := &FakeT{buffer: new(bytes.Buffer)}
+	assertion := New(fake)
+	passed := assertion.So(1, ShouldEqual, 1)
+
+	if !passed {
+		t.Error("Assertion failed when it should have passed.")
+	}
+	if fake.buffer.Len() > 0 {
+		t.Error("Unexpected error message was printed.")
+	}
+}
+
+func TestFailingAssertion(t *testing.T) {
+	fake := &FakeT{buffer: new(bytes.Buffer)}
+	assertion := New(fake)
+	passed := assertion.So(1, ShouldEqual, 2)
+
+	if passed {
+		t.Error("Assertion passed when it should have failed.")
+	}
+	if fake.buffer.Len() == 0 {
+		t.Error("Expected error message not printed.")
+	}
+}
+
+func TestFailingGroupsOfAssertions(t *testing.T) {
+	fake := &FakeT{buffer: new(bytes.Buffer)}
+	assertion1 := New(fake)
+	assertion2 := New(fake)
+
+	assertion1.So(1, ShouldEqual, 2) // fail
+	assertion2.So(1, ShouldEqual, 1) // pass
+
+	if !assertion1.Failed() {
+		t.Error("Expected the first assertion to have been marked as failed.")
+	}
+	if assertion2.Failed() {
+		t.Error("Expected the second assertion to NOT have been marked as failed.")
+	}
+}
+
+type FakeT struct {
+	buffer *bytes.Buffer
+}
+
+func (this *FakeT) Error(args ...interface{}) {
+	fmt.Fprint(this.buffer, args...)
+}

--- a/vendor/github.com/smartystreets/assertions/equality.go
+++ b/vendor/github.com/smartystreets/assertions/equality.go
@@ -1,0 +1,280 @@
+package assertions
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+
+	"github.com/smartystreets/assertions/internal/go-render/render"
+	"github.com/smartystreets/assertions/internal/oglematchers"
+)
+
+// default acceptable delta for ShouldAlmostEqual
+const defaultDelta = 0.0000000001
+
+// ShouldEqual receives exactly two parameters and does an equality check.
+func ShouldEqual(actual interface{}, expected ...interface{}) string {
+	if message := need(1, expected); message != success {
+		return message
+	}
+	return shouldEqual(actual, expected[0])
+}
+func shouldEqual(actual, expected interface{}) (message string) {
+	defer func() {
+		if r := recover(); r != nil {
+			message = serializer.serialize(expected, actual, fmt.Sprintf(shouldHaveBeenEqual, expected, actual))
+			return
+		}
+	}()
+
+	if matchError := oglematchers.Equals(expected).Matches(actual); matchError != nil {
+		expectedSyntax := fmt.Sprintf("%v", expected)
+		actualSyntax := fmt.Sprintf("%v", actual)
+		if expectedSyntax == actualSyntax && reflect.TypeOf(expected) != reflect.TypeOf(actual) {
+			message = fmt.Sprintf(shouldHaveBeenEqualTypeMismatch, expected, expected, actual, actual)
+		} else {
+			message = fmt.Sprintf(shouldHaveBeenEqual, expected, actual)
+		}
+		message = serializer.serialize(expected, actual, message)
+		return
+	}
+
+	return success
+}
+
+// ShouldNotEqual receives exactly two parameters and does an inequality check.
+func ShouldNotEqual(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	} else if ShouldEqual(actual, expected[0]) == success {
+		return fmt.Sprintf(shouldNotHaveBeenEqual, actual, expected[0])
+	}
+	return success
+}
+
+// ShouldAlmostEqual makes sure that two parameters are close enough to being equal.
+// The acceptable delta may be specified with a third argument,
+// or a very small default delta will be used.
+func ShouldAlmostEqual(actual interface{}, expected ...interface{}) string {
+	actualFloat, expectedFloat, deltaFloat, err := cleanAlmostEqualInput(actual, expected...)
+
+	if err != "" {
+		return err
+	}
+
+	if math.Abs(actualFloat-expectedFloat) <= deltaFloat {
+		return success
+	} else {
+		return fmt.Sprintf(shouldHaveBeenAlmostEqual, actualFloat, expectedFloat)
+	}
+}
+
+// ShouldNotAlmostEqual is the inverse of ShouldAlmostEqual
+func ShouldNotAlmostEqual(actual interface{}, expected ...interface{}) string {
+	actualFloat, expectedFloat, deltaFloat, err := cleanAlmostEqualInput(actual, expected...)
+
+	if err != "" {
+		return err
+	}
+
+	if math.Abs(actualFloat-expectedFloat) > deltaFloat {
+		return success
+	} else {
+		return fmt.Sprintf(shouldHaveNotBeenAlmostEqual, actualFloat, expectedFloat)
+	}
+}
+
+func cleanAlmostEqualInput(actual interface{}, expected ...interface{}) (float64, float64, float64, string) {
+	deltaFloat := 0.0000000001
+
+	if len(expected) == 0 {
+		return 0.0, 0.0, 0.0, "This assertion requires exactly one comparison value and an optional delta (you provided neither)"
+	} else if len(expected) == 2 {
+		delta, err := getFloat(expected[1])
+
+		if err != nil {
+			return 0.0, 0.0, 0.0, "delta must be a numerical type"
+		}
+
+		deltaFloat = delta
+	} else if len(expected) > 2 {
+		return 0.0, 0.0, 0.0, "This assertion requires exactly one comparison value and an optional delta (you provided more values)"
+	}
+
+	actualFloat, err := getFloat(actual)
+
+	if err != nil {
+		return 0.0, 0.0, 0.0, err.Error()
+	}
+
+	expectedFloat, err := getFloat(expected[0])
+
+	if err != nil {
+		return 0.0, 0.0, 0.0, err.Error()
+	}
+
+	return actualFloat, expectedFloat, deltaFloat, ""
+}
+
+// returns the float value of any real number, or error if it is not a numerical type
+func getFloat(num interface{}) (float64, error) {
+	numValue := reflect.ValueOf(num)
+	numKind := numValue.Kind()
+
+	if numKind == reflect.Int ||
+		numKind == reflect.Int8 ||
+		numKind == reflect.Int16 ||
+		numKind == reflect.Int32 ||
+		numKind == reflect.Int64 {
+		return float64(numValue.Int()), nil
+	} else if numKind == reflect.Uint ||
+		numKind == reflect.Uint8 ||
+		numKind == reflect.Uint16 ||
+		numKind == reflect.Uint32 ||
+		numKind == reflect.Uint64 {
+		return float64(numValue.Uint()), nil
+	} else if numKind == reflect.Float32 ||
+		numKind == reflect.Float64 {
+		return numValue.Float(), nil
+	} else {
+		return 0.0, errors.New("must be a numerical type, but was " + numKind.String())
+	}
+}
+
+// ShouldResemble receives exactly two parameters and does a deep equal check (see reflect.DeepEqual)
+func ShouldResemble(actual interface{}, expected ...interface{}) string {
+	if message := need(1, expected); message != success {
+		return message
+	}
+
+	if matchError := oglematchers.DeepEquals(expected[0]).Matches(actual); matchError != nil {
+		return serializer.serializeDetailed(expected[0], actual,
+			fmt.Sprintf(shouldHaveResembled, render.Render(expected[0]), render.Render(actual)))
+	}
+
+	return success
+}
+
+// ShouldNotResemble receives exactly two parameters and does an inverse deep equal check (see reflect.DeepEqual)
+func ShouldNotResemble(actual interface{}, expected ...interface{}) string {
+	if message := need(1, expected); message != success {
+		return message
+	} else if ShouldResemble(actual, expected[0]) == success {
+		return fmt.Sprintf(shouldNotHaveResembled, render.Render(actual), render.Render(expected[0]))
+	}
+	return success
+}
+
+// ShouldPointTo receives exactly two parameters and checks to see that they point to the same address.
+func ShouldPointTo(actual interface{}, expected ...interface{}) string {
+	if message := need(1, expected); message != success {
+		return message
+	}
+	return shouldPointTo(actual, expected[0])
+
+}
+func shouldPointTo(actual, expected interface{}) string {
+	actualValue := reflect.ValueOf(actual)
+	expectedValue := reflect.ValueOf(expected)
+
+	if ShouldNotBeNil(actual) != success {
+		return fmt.Sprintf(shouldHaveBeenNonNilPointer, "first", "nil")
+	} else if ShouldNotBeNil(expected) != success {
+		return fmt.Sprintf(shouldHaveBeenNonNilPointer, "second", "nil")
+	} else if actualValue.Kind() != reflect.Ptr {
+		return fmt.Sprintf(shouldHaveBeenNonNilPointer, "first", "not")
+	} else if expectedValue.Kind() != reflect.Ptr {
+		return fmt.Sprintf(shouldHaveBeenNonNilPointer, "second", "not")
+	} else if ShouldEqual(actualValue.Pointer(), expectedValue.Pointer()) != success {
+		actualAddress := reflect.ValueOf(actual).Pointer()
+		expectedAddress := reflect.ValueOf(expected).Pointer()
+		return serializer.serialize(expectedAddress, actualAddress, fmt.Sprintf(shouldHavePointedTo,
+			actual, actualAddress,
+			expected, expectedAddress))
+	}
+	return success
+}
+
+// ShouldNotPointTo receives exactly two parameters and checks to see that they point to different addresess.
+func ShouldNotPointTo(actual interface{}, expected ...interface{}) string {
+	if message := need(1, expected); message != success {
+		return message
+	}
+	compare := ShouldPointTo(actual, expected[0])
+	if strings.HasPrefix(compare, shouldBePointers) {
+		return compare
+	} else if compare == success {
+		return fmt.Sprintf(shouldNotHavePointedTo, actual, expected[0], reflect.ValueOf(actual).Pointer())
+	}
+	return success
+}
+
+// ShouldBeNil receives a single parameter and ensures that it is nil.
+func ShouldBeNil(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	} else if actual == nil {
+		return success
+	} else if interfaceHasNilValue(actual) {
+		return success
+	}
+	return fmt.Sprintf(shouldHaveBeenNil, actual)
+}
+func interfaceHasNilValue(actual interface{}) bool {
+	value := reflect.ValueOf(actual)
+	kind := value.Kind()
+	nilable := kind == reflect.Slice ||
+		kind == reflect.Chan ||
+		kind == reflect.Func ||
+		kind == reflect.Ptr ||
+		kind == reflect.Map
+
+	// Careful: reflect.Value.IsNil() will panic unless it's an interface, chan, map, func, slice, or ptr
+	// Reference: http://golang.org/pkg/reflect/#Value.IsNil
+	return nilable && value.IsNil()
+}
+
+// ShouldNotBeNil receives a single parameter and ensures that it is not nil.
+func ShouldNotBeNil(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	} else if ShouldBeNil(actual) == success {
+		return fmt.Sprintf(shouldNotHaveBeenNil, actual)
+	}
+	return success
+}
+
+// ShouldBeTrue receives a single parameter and ensures that it is true.
+func ShouldBeTrue(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	} else if actual != true {
+		return fmt.Sprintf(shouldHaveBeenTrue, actual)
+	}
+	return success
+}
+
+// ShouldBeFalse receives a single parameter and ensures that it is false.
+func ShouldBeFalse(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	} else if actual != false {
+		return fmt.Sprintf(shouldHaveBeenFalse, actual)
+	}
+	return success
+}
+
+// ShouldBeZeroValue receives a single parameter and ensures that it is
+// the Go equivalent of the default value, or "zero" value.
+func ShouldBeZeroValue(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	}
+	zeroVal := reflect.Zero(reflect.TypeOf(actual)).Interface()
+	if !reflect.DeepEqual(zeroVal, actual) {
+		return serializer.serialize(zeroVal, actual, fmt.Sprintf(shouldHaveBeenZeroValue, actual))
+	}
+	return success
+}

--- a/vendor/github.com/smartystreets/assertions/equality_test.go
+++ b/vendor/github.com/smartystreets/assertions/equality_test.go
@@ -1,0 +1,269 @@
+package assertions
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestShouldEqual(t *testing.T) {
+	serializer = newFakeSerializer()
+
+	fail(t, so(1, ShouldEqual), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(1, ShouldEqual, 1, 2), "This assertion requires exactly 1 comparison values (you provided 2).")
+	fail(t, so(1, ShouldEqual, 1, 2, 3), "This assertion requires exactly 1 comparison values (you provided 3).")
+
+	pass(t, so(1, ShouldEqual, 1))
+	fail(t, so(1, ShouldEqual, 2), "2|1|Expected: '2' Actual: '1' (Should be equal)")
+	fail(t, so(1, ShouldEqual, "1"), "1|1|Expected: '1' (string) Actual: '1' (int) (Should be equal, type mismatch)")
+
+	pass(t, so(true, ShouldEqual, true))
+	fail(t, so(true, ShouldEqual, false), "false|true|Expected: 'false' Actual: 'true' (Should be equal)")
+
+	pass(t, so("hi", ShouldEqual, "hi"))
+	fail(t, so("hi", ShouldEqual, "bye"), "bye|hi|Expected: 'bye' Actual: 'hi' (Should be equal)")
+
+	pass(t, so(42, ShouldEqual, uint(42)))
+
+	fail(t, so(Thing1{"hi"}, ShouldEqual, Thing1{}), "{}|{hi}|Expected: '{}' Actual: '{hi}' (Should be equal)")
+	fail(t, so(Thing1{"hi"}, ShouldEqual, Thing1{"hi"}), "{hi}|{hi}|Expected: '{hi}' Actual: '{hi}' (Should be equal)")
+	fail(t, so(&Thing1{"hi"}, ShouldEqual, &Thing1{"hi"}), "&{hi}|&{hi}|Expected: '&{hi}' Actual: '&{hi}' (Should be equal)")
+
+	fail(t, so(Thing1{}, ShouldEqual, Thing2{}), "{}|{}|Expected: '{}' Actual: '{}' (Should be equal)")
+}
+
+func TestShouldNotEqual(t *testing.T) {
+	fail(t, so(1, ShouldNotEqual), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(1, ShouldNotEqual, 1, 2), "This assertion requires exactly 1 comparison values (you provided 2).")
+	fail(t, so(1, ShouldNotEqual, 1, 2, 3), "This assertion requires exactly 1 comparison values (you provided 3).")
+
+	pass(t, so(1, ShouldNotEqual, 2))
+	pass(t, so(1, ShouldNotEqual, "1"))
+	fail(t, so(1, ShouldNotEqual, 1), "Expected '1' to NOT equal '1' (but it did)!")
+
+	pass(t, so(true, ShouldNotEqual, false))
+	fail(t, so(true, ShouldNotEqual, true), "Expected 'true' to NOT equal 'true' (but it did)!")
+
+	pass(t, so("hi", ShouldNotEqual, "bye"))
+	fail(t, so("hi", ShouldNotEqual, "hi"), "Expected 'hi' to NOT equal 'hi' (but it did)!")
+
+	pass(t, so(&Thing1{"hi"}, ShouldNotEqual, &Thing1{"hi"}))
+	pass(t, so(Thing1{"hi"}, ShouldNotEqual, Thing1{"hi"}))
+	pass(t, so(Thing1{}, ShouldNotEqual, Thing1{}))
+	pass(t, so(Thing1{}, ShouldNotEqual, Thing2{}))
+}
+
+func TestShouldAlmostEqual(t *testing.T) {
+	fail(t, so(1, ShouldAlmostEqual), "This assertion requires exactly one comparison value and an optional delta (you provided neither)")
+	fail(t, so(1, ShouldAlmostEqual, 1, 2, 3), "This assertion requires exactly one comparison value and an optional delta (you provided more values)")
+
+	// with the default delta
+	pass(t, so(1, ShouldAlmostEqual, .99999999999999))
+	pass(t, so(1.3612499999999996, ShouldAlmostEqual, 1.36125))
+	pass(t, so(0.7285312499999999, ShouldAlmostEqual, 0.72853125))
+	fail(t, so(1, ShouldAlmostEqual, .99), "Expected '1' to almost equal '0.99' (but it didn't)!")
+
+	// with a different delta
+	pass(t, so(100.0, ShouldAlmostEqual, 110.0, 10.0))
+	fail(t, so(100.0, ShouldAlmostEqual, 111.0, 10.5), "Expected '100' to almost equal '111' (but it didn't)!")
+
+	// ints should work
+	pass(t, so(100, ShouldAlmostEqual, 100.0))
+	fail(t, so(100, ShouldAlmostEqual, 99.0), "Expected '100' to almost equal '99' (but it didn't)!")
+
+	// float32 should work
+	pass(t, so(float64(100.0), ShouldAlmostEqual, float32(100.0)))
+	fail(t, so(float32(100.0), ShouldAlmostEqual, 99.0, float32(0.1)), "Expected '100' to almost equal '99' (but it didn't)!")
+}
+
+func TestShouldNotAlmostEqual(t *testing.T) {
+	fail(t, so(1, ShouldNotAlmostEqual), "This assertion requires exactly one comparison value and an optional delta (you provided neither)")
+	fail(t, so(1, ShouldNotAlmostEqual, 1, 2, 3), "This assertion requires exactly one comparison value and an optional delta (you provided more values)")
+
+	// with the default delta
+	fail(t, so(1, ShouldNotAlmostEqual, .99999999999999), "Expected '1' to NOT almost equal '0.99999999999999' (but it did)!")
+	fail(t, so(1.3612499999999996, ShouldNotAlmostEqual, 1.36125), "Expected '1.3612499999999996' to NOT almost equal '1.36125' (but it did)!")
+	pass(t, so(1, ShouldNotAlmostEqual, .99))
+
+	// with a different delta
+	fail(t, so(100.0, ShouldNotAlmostEqual, 110.0, 10.0), "Expected '100' to NOT almost equal '110' (but it did)!")
+	pass(t, so(100.0, ShouldNotAlmostEqual, 111.0, 10.5))
+
+	// ints should work
+	fail(t, so(100, ShouldNotAlmostEqual, 100.0), "Expected '100' to NOT almost equal '100' (but it did)!")
+	pass(t, so(100, ShouldNotAlmostEqual, 99.0))
+
+	// float32 should work
+	fail(t, so(float64(100.0), ShouldNotAlmostEqual, float32(100.0)), "Expected '100' to NOT almost equal '100' (but it did)!")
+	pass(t, so(float32(100.0), ShouldNotAlmostEqual, 99.0, float32(0.1)))
+}
+
+func TestShouldResemble(t *testing.T) {
+	serializer = newFakeSerializer()
+
+	fail(t, so(Thing1{"hi"}, ShouldResemble), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(Thing1{"hi"}, ShouldResemble, Thing1{"hi"}, Thing1{"hi"}), "This assertion requires exactly 1 comparison values (you provided 2).")
+
+	pass(t, so(Thing1{"hi"}, ShouldResemble, Thing1{"hi"}))
+	fail(t, so(Thing1{"hi"}, ShouldResemble, Thing1{"bye"}), `{bye}|{hi}|Expected: 'assertions.Thing1{a:"bye"}' Actual: 'assertions.Thing1{a:"hi"}' (Should resemble)!`)
+
+	var (
+		a []int
+		b []int = []int{}
+	)
+
+	fail(t, so(a, ShouldResemble, b), `[]|[]|Expected: '[]int{}' Actual: '[]int(nil)' (Should resemble)!`)
+	fail(t, so(2, ShouldResemble, 1), `1|2|Expected: '1' Actual: '2' (Should resemble)!`)
+
+	fail(t, so(StringStringMapAlias{"hi": "bye"}, ShouldResemble, map[string]string{"hi": "bye"}),
+		`map[hi:bye]|map[hi:bye]|Expected: 'map[string]string{"hi":"bye"}' Actual: 'assertions.StringStringMapAlias{"hi":"bye"}' (Should resemble)!`)
+	fail(t, so(StringSliceAlias{"hi", "bye"}, ShouldResemble, []string{"hi", "bye"}),
+		`[hi bye]|[hi bye]|Expected: '[]string{"hi", "bye"}' Actual: 'assertions.StringSliceAlias{"hi", "bye"}' (Should resemble)!`)
+
+	// some types come out looking the same when represented with "%#v" so we show type mismatch info:
+	fail(t, so(StringAlias("hi"), ShouldResemble, "hi"), `hi|hi|Expected: '"hi"' Actual: 'assertions.StringAlias("hi")' (Should resemble)!`)
+	fail(t, so(IntAlias(42), ShouldResemble, 42), `42|42|Expected: '42' Actual: 'assertions.IntAlias(42)' (Should resemble)!`)
+}
+
+func TestShouldNotResemble(t *testing.T) {
+	fail(t, so(Thing1{"hi"}, ShouldNotResemble), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(Thing1{"hi"}, ShouldNotResemble, Thing1{"hi"}, Thing1{"hi"}), "This assertion requires exactly 1 comparison values (you provided 2).")
+
+	pass(t, so(Thing1{"hi"}, ShouldNotResemble, Thing1{"bye"}))
+	fail(t, so(Thing1{"hi"}, ShouldNotResemble, Thing1{"hi"}),
+		`Expected '"assertions.Thing1{a:\"hi\"}"' to NOT resemble '"assertions.Thing1{a:\"hi\"}"' (but it did)!`)
+
+	pass(t, so(map[string]string{"hi": "bye"}, ShouldResemble, map[string]string{"hi": "bye"}))
+	pass(t, so(IntAlias(42), ShouldNotResemble, 42))
+
+	pass(t, so(StringSliceAlias{"hi", "bye"}, ShouldNotResemble, []string{"hi", "bye"}))
+}
+
+func TestShouldPointTo(t *testing.T) {
+	serializer = newFakeSerializer()
+
+	t1 := &Thing1{}
+	t2 := t1
+	t3 := &Thing1{}
+
+	pointer1 := reflect.ValueOf(t1).Pointer()
+	pointer3 := reflect.ValueOf(t3).Pointer()
+
+	fail(t, so(t1, ShouldPointTo), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(t1, ShouldPointTo, t2, t3), "This assertion requires exactly 1 comparison values (you provided 2).")
+
+	pass(t, so(t1, ShouldPointTo, t2))
+	fail(t, so(t1, ShouldPointTo, t3), fmt.Sprintf(
+		"%v|%v|Expected '&{a:}' (address: '%v') and '&{a:}' (address: '%v') to be the same address (but their weren't)!",
+		pointer3, pointer1, pointer1, pointer3))
+
+	t4 := Thing1{}
+	t5 := t4
+
+	fail(t, so(t4, ShouldPointTo, t5), "Both arguments should be pointers (the first was not)!")
+	fail(t, so(&t4, ShouldPointTo, t5), "Both arguments should be pointers (the second was not)!")
+	fail(t, so(nil, ShouldPointTo, nil), "Both arguments should be pointers (the first was nil)!")
+	fail(t, so(&t4, ShouldPointTo, nil), "Both arguments should be pointers (the second was nil)!")
+}
+
+func TestShouldNotPointTo(t *testing.T) {
+	t1 := &Thing1{}
+	t2 := t1
+	t3 := &Thing1{}
+
+	pointer1 := reflect.ValueOf(t1).Pointer()
+
+	fail(t, so(t1, ShouldNotPointTo), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(t1, ShouldNotPointTo, t2, t3), "This assertion requires exactly 1 comparison values (you provided 2).")
+
+	pass(t, so(t1, ShouldNotPointTo, t3))
+	fail(t, so(t1, ShouldNotPointTo, t2), fmt.Sprintf("Expected '&{a:}' and '&{a:}' to be different references (but they matched: '%v')!", pointer1))
+
+	t4 := Thing1{}
+	t5 := t4
+
+	fail(t, so(t4, ShouldNotPointTo, t5), "Both arguments should be pointers (the first was not)!")
+	fail(t, so(&t4, ShouldNotPointTo, t5), "Both arguments should be pointers (the second was not)!")
+	fail(t, so(nil, ShouldNotPointTo, nil), "Both arguments should be pointers (the first was nil)!")
+	fail(t, so(&t4, ShouldNotPointTo, nil), "Both arguments should be pointers (the second was nil)!")
+}
+
+func TestShouldBeNil(t *testing.T) {
+	fail(t, so(nil, ShouldBeNil, nil, nil, nil), "This assertion requires exactly 0 comparison values (you provided 3).")
+	fail(t, so(nil, ShouldBeNil, nil), "This assertion requires exactly 0 comparison values (you provided 1).")
+
+	pass(t, so(nil, ShouldBeNil))
+	fail(t, so(1, ShouldBeNil), "Expected: nil Actual: '1'")
+
+	var thing Thinger
+	pass(t, so(thing, ShouldBeNil))
+	thing = &Thing{}
+	fail(t, so(thing, ShouldBeNil), "Expected: nil Actual: '&{}'")
+
+	var thingOne *Thing1
+	pass(t, so(thingOne, ShouldBeNil))
+
+	var nilSlice []int = nil
+	pass(t, so(nilSlice, ShouldBeNil))
+
+	var nilMap map[string]string = nil
+	pass(t, so(nilMap, ShouldBeNil))
+
+	var nilChannel chan int = nil
+	pass(t, so(nilChannel, ShouldBeNil))
+
+	var nilFunc func() = nil
+	pass(t, so(nilFunc, ShouldBeNil))
+
+	var nilInterface interface{} = nil
+	pass(t, so(nilInterface, ShouldBeNil))
+}
+
+func TestShouldNotBeNil(t *testing.T) {
+	fail(t, so(nil, ShouldNotBeNil, nil, nil, nil), "This assertion requires exactly 0 comparison values (you provided 3).")
+	fail(t, so(nil, ShouldNotBeNil, nil), "This assertion requires exactly 0 comparison values (you provided 1).")
+
+	fail(t, so(nil, ShouldNotBeNil), "Expected '<nil>' to NOT be nil (but it was)!")
+	pass(t, so(1, ShouldNotBeNil))
+
+	var thing Thinger
+	fail(t, so(thing, ShouldNotBeNil), "Expected '<nil>' to NOT be nil (but it was)!")
+	thing = &Thing{}
+	pass(t, so(thing, ShouldNotBeNil))
+}
+
+func TestShouldBeTrue(t *testing.T) {
+	fail(t, so(true, ShouldBeTrue, 1, 2, 3), "This assertion requires exactly 0 comparison values (you provided 3).")
+	fail(t, so(true, ShouldBeTrue, 1), "This assertion requires exactly 0 comparison values (you provided 1).")
+
+	fail(t, so(false, ShouldBeTrue), "Expected: true Actual: false")
+	fail(t, so(1, ShouldBeTrue), "Expected: true Actual: 1")
+	pass(t, so(true, ShouldBeTrue))
+}
+
+func TestShouldBeFalse(t *testing.T) {
+	fail(t, so(false, ShouldBeFalse, 1, 2, 3), "This assertion requires exactly 0 comparison values (you provided 3).")
+	fail(t, so(false, ShouldBeFalse, 1), "This assertion requires exactly 0 comparison values (you provided 1).")
+
+	fail(t, so(true, ShouldBeFalse), "Expected: false Actual: true")
+	fail(t, so(1, ShouldBeFalse), "Expected: false Actual: 1")
+	pass(t, so(false, ShouldBeFalse))
+}
+
+func TestShouldBeZeroValue(t *testing.T) {
+	serializer = newFakeSerializer()
+
+	fail(t, so(0, ShouldBeZeroValue, 1, 2, 3), "This assertion requires exactly 0 comparison values (you provided 3).")
+	fail(t, so(false, ShouldBeZeroValue, true), "This assertion requires exactly 0 comparison values (you provided 1).")
+
+	fail(t, so(1, ShouldBeZeroValue), "0|1|'1' should have been the zero value")                                       //"Expected: (zero value) Actual: 1")
+	fail(t, so(true, ShouldBeZeroValue), "false|true|'true' should have been the zero value")                          //"Expected: (zero value) Actual: true")
+	fail(t, so("123", ShouldBeZeroValue), "|123|'123' should have been the zero value")                                //"Expected: (zero value) Actual: 123")
+	fail(t, so(" ", ShouldBeZeroValue), "| |' ' should have been the zero value")                                      //"Expected: (zero value) Actual:  ")
+	fail(t, so([]string{"Nonempty"}, ShouldBeZeroValue), "[]|[Nonempty]|'[Nonempty]' should have been the zero value") //"Expected: (zero value) Actual: [Nonempty]")
+	fail(t, so(struct{ a string }{a: "asdf"}, ShouldBeZeroValue), "{}|{asdf}|'{a:asdf}' should have been the zero value")
+	pass(t, so(0, ShouldBeZeroValue))
+	pass(t, so(false, ShouldBeZeroValue))
+	pass(t, so("", ShouldBeZeroValue))
+	pass(t, so(struct{}{}, ShouldBeZeroValue))
+}

--- a/vendor/github.com/smartystreets/assertions/filter.go
+++ b/vendor/github.com/smartystreets/assertions/filter.go
@@ -1,0 +1,23 @@
+package assertions
+
+import "fmt"
+
+const (
+	success                = ""
+	needExactValues        = "This assertion requires exactly %d comparison values (you provided %d)."
+	needNonEmptyCollection = "This assertion requires at least 1 comparison value (you provided 0)."
+)
+
+func need(needed int, expected []interface{}) string {
+	if len(expected) != needed {
+		return fmt.Sprintf(needExactValues, needed, len(expected))
+	}
+	return success
+}
+
+func atLeast(minimum int, expected []interface{}) string {
+	if len(expected) < 1 {
+		return needNonEmptyCollection
+	}
+	return success
+}

--- a/vendor/github.com/smartystreets/assertions/internal/go-render/LICENSE
+++ b/vendor/github.com/smartystreets/assertions/internal/go-render/LICENSE
@@ -1,0 +1,27 @@
+// Copyright (c) 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/smartystreets/assertions/internal/go-render/render/render.go
+++ b/vendor/github.com/smartystreets/assertions/internal/go-render/render/render.go
@@ -1,0 +1,477 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package render
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+)
+
+var builtinTypeMap = map[reflect.Kind]string{
+	reflect.Bool:       "bool",
+	reflect.Complex128: "complex128",
+	reflect.Complex64:  "complex64",
+	reflect.Float32:    "float32",
+	reflect.Float64:    "float64",
+	reflect.Int16:      "int16",
+	reflect.Int32:      "int32",
+	reflect.Int64:      "int64",
+	reflect.Int8:       "int8",
+	reflect.Int:        "int",
+	reflect.String:     "string",
+	reflect.Uint16:     "uint16",
+	reflect.Uint32:     "uint32",
+	reflect.Uint64:     "uint64",
+	reflect.Uint8:      "uint8",
+	reflect.Uint:       "uint",
+	reflect.Uintptr:    "uintptr",
+}
+
+var builtinTypeSet = map[string]struct{}{}
+
+func init() {
+	for _, v := range builtinTypeMap {
+		builtinTypeSet[v] = struct{}{}
+	}
+}
+
+var typeOfString = reflect.TypeOf("")
+var typeOfInt = reflect.TypeOf(int(1))
+var typeOfUint = reflect.TypeOf(uint(1))
+var typeOfFloat = reflect.TypeOf(10.1)
+
+// Render converts a structure to a string representation. Unline the "%#v"
+// format string, this resolves pointer types' contents in structs, maps, and
+// slices/arrays and prints their field values.
+func Render(v interface{}) string {
+	buf := bytes.Buffer{}
+	s := (*traverseState)(nil)
+	s.render(&buf, 0, reflect.ValueOf(v), false)
+	return buf.String()
+}
+
+// renderPointer is called to render a pointer value.
+//
+// This is overridable so that the test suite can have deterministic pointer
+// values in its expectations.
+var renderPointer = func(buf *bytes.Buffer, p uintptr) {
+	fmt.Fprintf(buf, "0x%016x", p)
+}
+
+// traverseState is used to note and avoid recursion as struct members are being
+// traversed.
+//
+// traverseState is allowed to be nil. Specifically, the root state is nil.
+type traverseState struct {
+	parent *traverseState
+	ptr    uintptr
+}
+
+func (s *traverseState) forkFor(ptr uintptr) *traverseState {
+	for cur := s; cur != nil; cur = cur.parent {
+		if ptr == cur.ptr {
+			return nil
+		}
+	}
+
+	fs := &traverseState{
+		parent: s,
+		ptr:    ptr,
+	}
+	return fs
+}
+
+func (s *traverseState) render(buf *bytes.Buffer, ptrs int, v reflect.Value, implicit bool) {
+	if v.Kind() == reflect.Invalid {
+		buf.WriteString("nil")
+		return
+	}
+	vt := v.Type()
+
+	// If the type being rendered is a potentially recursive type (a type that
+	// can contain itself as a member), we need to avoid recursion.
+	//
+	// If we've already seen this type before, mark that this is the case and
+	// write a recursion placeholder instead of actually rendering it.
+	//
+	// If we haven't seen it before, fork our `seen` tracking so any higher-up
+	// renderers will also render it at least once, then mark that we've seen it
+	// to avoid recursing on lower layers.
+	pe := uintptr(0)
+	vk := vt.Kind()
+	switch vk {
+	case reflect.Ptr:
+		// Since structs and arrays aren't pointers, they can't directly be
+		// recursed, but they can contain pointers to themselves. Record their
+		// pointer to avoid this.
+		switch v.Elem().Kind() {
+		case reflect.Struct, reflect.Array:
+			pe = v.Pointer()
+		}
+
+	case reflect.Slice, reflect.Map:
+		pe = v.Pointer()
+	}
+	if pe != 0 {
+		s = s.forkFor(pe)
+		if s == nil {
+			buf.WriteString("<REC(")
+			if !implicit {
+				writeType(buf, ptrs, vt)
+			}
+			buf.WriteString(")>")
+			return
+		}
+	}
+
+	isAnon := func(t reflect.Type) bool {
+		if t.Name() != "" {
+			if _, ok := builtinTypeSet[t.Name()]; !ok {
+				return false
+			}
+		}
+		return t.Kind() != reflect.Interface
+	}
+
+	switch vk {
+	case reflect.Struct:
+		if !implicit {
+			writeType(buf, ptrs, vt)
+		}
+		structAnon := vt.Name() == ""
+		buf.WriteRune('{')
+		for i := 0; i < vt.NumField(); i++ {
+			if i > 0 {
+				buf.WriteString(", ")
+			}
+			anon := structAnon && isAnon(vt.Field(i).Type)
+
+			if !anon {
+				buf.WriteString(vt.Field(i).Name)
+				buf.WriteRune(':')
+			}
+
+			s.render(buf, 0, v.Field(i), anon)
+		}
+		buf.WriteRune('}')
+
+	case reflect.Slice:
+		if v.IsNil() {
+			if !implicit {
+				writeType(buf, ptrs, vt)
+				buf.WriteString("(nil)")
+			} else {
+				buf.WriteString("nil")
+			}
+			return
+		}
+		fallthrough
+
+	case reflect.Array:
+		if !implicit {
+			writeType(buf, ptrs, vt)
+		}
+		anon := vt.Name() == "" && isAnon(vt.Elem())
+		buf.WriteString("{")
+		for i := 0; i < v.Len(); i++ {
+			if i > 0 {
+				buf.WriteString(", ")
+			}
+
+			s.render(buf, 0, v.Index(i), anon)
+		}
+		buf.WriteRune('}')
+
+	case reflect.Map:
+		if !implicit {
+			writeType(buf, ptrs, vt)
+		}
+		if v.IsNil() {
+			buf.WriteString("(nil)")
+		} else {
+			buf.WriteString("{")
+
+			mkeys := v.MapKeys()
+			tryAndSortMapKeys(vt, mkeys)
+
+			kt := vt.Key()
+			keyAnon := typeOfString.ConvertibleTo(kt) || typeOfInt.ConvertibleTo(kt) || typeOfUint.ConvertibleTo(kt) || typeOfFloat.ConvertibleTo(kt)
+			valAnon := vt.Name() == "" && isAnon(vt.Elem())
+			for i, mk := range mkeys {
+				if i > 0 {
+					buf.WriteString(", ")
+				}
+
+				s.render(buf, 0, mk, keyAnon)
+				buf.WriteString(":")
+				s.render(buf, 0, v.MapIndex(mk), valAnon)
+			}
+			buf.WriteRune('}')
+		}
+
+	case reflect.Ptr:
+		ptrs++
+		fallthrough
+	case reflect.Interface:
+		if v.IsNil() {
+			writeType(buf, ptrs, v.Type())
+			buf.WriteString("(nil)")
+		} else {
+			s.render(buf, ptrs, v.Elem(), false)
+		}
+
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		writeType(buf, ptrs, vt)
+		buf.WriteRune('(')
+		renderPointer(buf, v.Pointer())
+		buf.WriteRune(')')
+
+	default:
+		tstr := vt.String()
+		implicit = implicit || (ptrs == 0 && builtinTypeMap[vk] == tstr)
+		if !implicit {
+			writeType(buf, ptrs, vt)
+			buf.WriteRune('(')
+		}
+
+		switch vk {
+		case reflect.String:
+			fmt.Fprintf(buf, "%q", v.String())
+		case reflect.Bool:
+			fmt.Fprintf(buf, "%v", v.Bool())
+
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			fmt.Fprintf(buf, "%d", v.Int())
+
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			fmt.Fprintf(buf, "%d", v.Uint())
+
+		case reflect.Float32, reflect.Float64:
+			fmt.Fprintf(buf, "%g", v.Float())
+
+		case reflect.Complex64, reflect.Complex128:
+			fmt.Fprintf(buf, "%g", v.Complex())
+		}
+
+		if !implicit {
+			buf.WriteRune(')')
+		}
+	}
+}
+
+func writeType(buf *bytes.Buffer, ptrs int, t reflect.Type) {
+	parens := ptrs > 0
+	switch t.Kind() {
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		parens = true
+	}
+
+	if parens {
+		buf.WriteRune('(')
+		for i := 0; i < ptrs; i++ {
+			buf.WriteRune('*')
+		}
+	}
+
+	switch t.Kind() {
+	case reflect.Ptr:
+		if ptrs == 0 {
+			// This pointer was referenced from within writeType (e.g., as part of
+			// rendering a list), and so hasn't had its pointer asterisk accounted
+			// for.
+			buf.WriteRune('*')
+		}
+		writeType(buf, 0, t.Elem())
+
+	case reflect.Interface:
+		if n := t.Name(); n != "" {
+			buf.WriteString(t.String())
+		} else {
+			buf.WriteString("interface{}")
+		}
+
+	case reflect.Array:
+		buf.WriteRune('[')
+		buf.WriteString(strconv.FormatInt(int64(t.Len()), 10))
+		buf.WriteRune(']')
+		writeType(buf, 0, t.Elem())
+
+	case reflect.Slice:
+		if t == reflect.SliceOf(t.Elem()) {
+			buf.WriteString("[]")
+			writeType(buf, 0, t.Elem())
+		} else {
+			// Custom slice type, use type name.
+			buf.WriteString(t.String())
+		}
+
+	case reflect.Map:
+		if t == reflect.MapOf(t.Key(), t.Elem()) {
+			buf.WriteString("map[")
+			writeType(buf, 0, t.Key())
+			buf.WriteRune(']')
+			writeType(buf, 0, t.Elem())
+		} else {
+			// Custom map type, use type name.
+			buf.WriteString(t.String())
+		}
+
+	default:
+		buf.WriteString(t.String())
+	}
+
+	if parens {
+		buf.WriteRune(')')
+	}
+}
+
+type cmpFn func(a, b reflect.Value) int
+
+type sortableValueSlice struct {
+	cmp      cmpFn
+	elements []reflect.Value
+}
+
+func (s sortableValueSlice) Len() int {
+	return len(s.elements)
+}
+
+func (s sortableValueSlice) Less(i, j int) bool {
+	return s.cmp(s.elements[i], s.elements[j]) < 0
+}
+
+func (s sortableValueSlice) Swap(i, j int) {
+	s.elements[i], s.elements[j] = s.elements[j], s.elements[i]
+}
+
+// cmpForType returns a cmpFn which sorts the data for some type t in the same
+// order that a go-native map key is compared for equality.
+func cmpForType(t reflect.Type) cmpFn {
+	switch t.Kind() {
+	case reflect.String:
+		return func(av, bv reflect.Value) int {
+			a, b := av.String(), bv.String()
+			if a < b {
+				return -1
+			} else if a > b {
+				return 1
+			}
+			return 0
+		}
+
+	case reflect.Bool:
+		return func(av, bv reflect.Value) int {
+			a, b := av.Bool(), bv.Bool()
+			if !a && b {
+				return -1
+			} else if a && !b {
+				return 1
+			}
+			return 0
+		}
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return func(av, bv reflect.Value) int {
+			a, b := av.Int(), bv.Int()
+			if a < b {
+				return -1
+			} else if a > b {
+				return 1
+			}
+			return 0
+		}
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32,
+		reflect.Uint64, reflect.Uintptr, reflect.UnsafePointer:
+		return func(av, bv reflect.Value) int {
+			a, b := av.Uint(), bv.Uint()
+			if a < b {
+				return -1
+			} else if a > b {
+				return 1
+			}
+			return 0
+		}
+
+	case reflect.Float32, reflect.Float64:
+		return func(av, bv reflect.Value) int {
+			a, b := av.Float(), bv.Float()
+			if a < b {
+				return -1
+			} else if a > b {
+				return 1
+			}
+			return 0
+		}
+
+	case reflect.Interface:
+		return func(av, bv reflect.Value) int {
+			a, b := av.InterfaceData(), bv.InterfaceData()
+			if a[0] < b[0] {
+				return -1
+			} else if a[0] > b[0] {
+				return 1
+			}
+			if a[1] < b[1] {
+				return -1
+			} else if a[1] > b[1] {
+				return 1
+			}
+			return 0
+		}
+
+	case reflect.Complex64, reflect.Complex128:
+		return func(av, bv reflect.Value) int {
+			a, b := av.Complex(), bv.Complex()
+			if real(a) < real(b) {
+				return -1
+			} else if real(a) > real(b) {
+				return 1
+			}
+			if imag(a) < imag(b) {
+				return -1
+			} else if imag(a) > imag(b) {
+				return 1
+			}
+			return 0
+		}
+
+	case reflect.Ptr, reflect.Chan:
+		return func(av, bv reflect.Value) int {
+			a, b := av.Pointer(), bv.Pointer()
+			if a < b {
+				return -1
+			} else if a > b {
+				return 1
+			}
+			return 0
+		}
+
+	case reflect.Struct:
+		cmpLst := make([]cmpFn, t.NumField())
+		for i := range cmpLst {
+			cmpLst[i] = cmpForType(t.Field(i).Type)
+		}
+		return func(a, b reflect.Value) int {
+			for i, cmp := range cmpLst {
+				if rslt := cmp(a.Field(i), b.Field(i)); rslt != 0 {
+					return rslt
+				}
+			}
+			return 0
+		}
+	}
+
+	return nil
+}
+
+func tryAndSortMapKeys(mt reflect.Type, k []reflect.Value) {
+	if cmp := cmpForType(mt.Key()); cmp != nil {
+		sort.Sort(sortableValueSlice{cmp, k})
+	}
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/LICENSE
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/README.md
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/README.md
@@ -1,0 +1,58 @@
+[![GoDoc](https://godoc.org/github.com/smartystreets/assertions/internal/oglematchers?status.svg)](https://godoc.org/github.com/smartystreets/assertions/internal/oglematchers)
+
+`oglematchers` is a package for the Go programming language containing a set of
+matchers, useful in a testing or mocking framework, inspired by and mostly
+compatible with [Google Test][googletest] for C++ and
+[Google JS Test][google-js-test]. The package is used by the
+[ogletest][ogletest] testing framework and [oglemock][oglemock] mocking
+framework, which may be more directly useful to you, but can be generically used
+elsewhere as well.
+
+A "matcher" is simply an object with a `Matches` method defining a set of golang
+values matched by the matcher, and a `Description` method describing that set.
+For example, here are some matchers:
+
+```go
+// Numbers
+Equals(17.13)
+LessThan(19)
+
+// Strings
+Equals("taco")
+HasSubstr("burrito")
+MatchesRegex("t.*o")
+
+// Combining matchers
+AnyOf(LessThan(17), GreaterThan(19))
+```
+
+There are lots more; see [here][reference] for a reference. You can also add
+your own simply by implementing the `oglematchers.Matcher` interface.
+
+
+Installation
+------------
+
+First, make sure you have installed Go 1.0.2 or newer. See
+[here][golang-install] for instructions.
+
+Use the following command to install `oglematchers` and keep it up to date:
+
+    go get -u github.com/smartystreets/assertions/internal/oglematchers
+
+
+Documentation
+-------------
+
+See [here][reference] for documentation. Alternatively, you can install the
+package and then use `godoc`:
+
+    godoc github.com/smartystreets/assertions/internal/oglematchers
+
+
+[reference]: http://godoc.org/github.com/smartystreets/assertions/internal/oglematchers
+[golang-install]: http://golang.org/doc/install.html
+[googletest]: http://code.google.com/p/googletest/
+[google-js-test]: http://code.google.com/p/google-js-test/
+[ogletest]: http://github.com/smartystreets/assertions/internal/ogletest
+[oglemock]: http://github.com/smartystreets/assertions/internal/oglemock

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/any_of.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/any_of.go
@@ -1,0 +1,94 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// AnyOf accepts a set of values S and returns a matcher that follows the
+// algorithm below when considering a candidate c:
+//
+//  1. If there exists a value m in S such that m implements the Matcher
+//     interface and m matches c, return true.
+//
+//  2. Otherwise, if there exists a value v in S such that v does not implement
+//     the Matcher interface and the matcher Equals(v) matches c, return true.
+//
+//  3. Otherwise, if there is a value m in S such that m implements the Matcher
+//     interface and m returns a fatal error for c, return that fatal error.
+//
+//  4. Otherwise, return false.
+//
+// This is akin to a logical OR operation for matchers, with non-matchers x
+// being treated as Equals(x).
+func AnyOf(vals ...interface{}) Matcher {
+	// Get ahold of a type variable for the Matcher interface.
+	var dummy *Matcher
+	matcherType := reflect.TypeOf(dummy).Elem()
+
+	// Create a matcher for each value, or use the value itself if it's already a
+	// matcher.
+	wrapped := make([]Matcher, len(vals))
+	for i, v := range vals {
+		t := reflect.TypeOf(v)
+		if t != nil && t.Implements(matcherType) {
+			wrapped[i] = v.(Matcher)
+		} else {
+			wrapped[i] = Equals(v)
+		}
+	}
+
+	return &anyOfMatcher{wrapped}
+}
+
+type anyOfMatcher struct {
+	wrapped []Matcher
+}
+
+func (m *anyOfMatcher) Description() string {
+	wrappedDescs := make([]string, len(m.wrapped))
+	for i, matcher := range m.wrapped {
+		wrappedDescs[i] = matcher.Description()
+	}
+
+	return fmt.Sprintf("or(%s)", strings.Join(wrappedDescs, ", "))
+}
+
+func (m *anyOfMatcher) Matches(c interface{}) (err error) {
+	err = errors.New("")
+
+	// Try each matcher in turn.
+	for _, matcher := range m.wrapped {
+		wrappedErr := matcher.Matches(c)
+
+		// Return immediately if there's a match.
+		if wrappedErr == nil {
+			err = nil
+			return
+		}
+
+		// Note the fatal error, if any.
+		if _, isFatal := wrappedErr.(*FatalError); isFatal {
+			err = wrappedErr
+		}
+	}
+
+	return
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/contains.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/contains.go
@@ -1,0 +1,61 @@
+// Copyright 2012 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Return a matcher that matches arrays slices with at least one element that
+// matches the supplied argument. If the argument x is not itself a Matcher,
+// this is equivalent to Contains(Equals(x)).
+func Contains(x interface{}) Matcher {
+	var result containsMatcher
+	var ok bool
+
+	if result.elementMatcher, ok = x.(Matcher); !ok {
+		result.elementMatcher = DeepEquals(x)
+	}
+
+	return &result
+}
+
+type containsMatcher struct {
+	elementMatcher Matcher
+}
+
+func (m *containsMatcher) Description() string {
+	return fmt.Sprintf("contains: %s", m.elementMatcher.Description())
+}
+
+func (m *containsMatcher) Matches(candidate interface{}) error {
+	// The candidate must be a slice or an array.
+	v := reflect.ValueOf(candidate)
+	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
+		return NewFatalError("which is not a slice or array")
+	}
+
+	// Check each element.
+	for i := 0; i < v.Len(); i++ {
+		elem := v.Index(i)
+		if matchErr := m.elementMatcher.Matches(elem.Interface()); matchErr == nil {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("")
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/deep_equals.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/deep_equals.go
@@ -1,0 +1,88 @@
+// Copyright 2012 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+var byteSliceType reflect.Type = reflect.TypeOf([]byte{})
+
+// DeepEquals returns a matcher that matches based on 'deep equality', as
+// defined by the reflect package. This matcher requires that values have
+// identical types to x.
+func DeepEquals(x interface{}) Matcher {
+	return &deepEqualsMatcher{x}
+}
+
+type deepEqualsMatcher struct {
+	x interface{}
+}
+
+func (m *deepEqualsMatcher) Description() string {
+	xDesc := fmt.Sprintf("%v", m.x)
+	xValue := reflect.ValueOf(m.x)
+
+	// Special case: fmt.Sprintf presents nil slices as "[]", but
+	// reflect.DeepEqual makes a distinction between nil and empty slices. Make
+	// this less confusing.
+	if xValue.Kind() == reflect.Slice && xValue.IsNil() {
+		xDesc = "<nil slice>"
+	}
+
+	return fmt.Sprintf("deep equals: %s", xDesc)
+}
+
+func (m *deepEqualsMatcher) Matches(c interface{}) error {
+	// Make sure the types match.
+	ct := reflect.TypeOf(c)
+	xt := reflect.TypeOf(m.x)
+
+	if ct != xt {
+		return NewFatalError(fmt.Sprintf("which is of type %v", ct))
+	}
+
+	// Special case: handle byte slices more efficiently.
+	cValue := reflect.ValueOf(c)
+	xValue := reflect.ValueOf(m.x)
+
+	if ct == byteSliceType && !cValue.IsNil() && !xValue.IsNil() {
+		xBytes := m.x.([]byte)
+		cBytes := c.([]byte)
+
+		if bytes.Equal(cBytes, xBytes) {
+			return nil
+		}
+
+		return errors.New("")
+	}
+
+	// Defer to the reflect package.
+	if reflect.DeepEqual(m.x, c) {
+		return nil
+	}
+
+	// Special case: if the comparison failed because c is the nil slice, given
+	// an indication of this (since its value is printed as "[]").
+	if cValue.Kind() == reflect.Slice && cValue.IsNil() {
+		return errors.New("which is nil")
+	}
+
+	return errors.New("")
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/equals.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/equals.go
@@ -1,0 +1,541 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+)
+
+// Equals(x) returns a matcher that matches values v such that v and x are
+// equivalent. This includes the case when the comparison v == x using Go's
+// built-in comparison operator is legal (except for structs, which this
+// matcher does not support), but for convenience the following rules also
+// apply:
+//
+//  *  Type checking is done based on underlying types rather than actual
+//     types, so that e.g. two aliases for string can be compared:
+//
+//         type stringAlias1 string
+//         type stringAlias2 string
+//
+//         a := "taco"
+//         b := stringAlias1("taco")
+//         c := stringAlias2("taco")
+//
+//         ExpectTrue(a == b)  // Legal, passes
+//         ExpectTrue(b == c)  // Illegal, doesn't compile
+//
+//         ExpectThat(a, Equals(b))  // Passes
+//         ExpectThat(b, Equals(c))  // Passes
+//
+//  *  Values of numeric type are treated as if they were abstract numbers, and
+//     compared accordingly. Therefore Equals(17) will match int(17),
+//     int16(17), uint(17), float32(17), complex64(17), and so on.
+//
+// If you want a stricter matcher that contains no such cleverness, see
+// IdenticalTo instead.
+//
+// Arrays are supported by this matcher, but do not participate in the
+// exceptions above. Two arrays compared with this matcher must have identical
+// types, and their element type must itself be comparable according to Go's ==
+// operator.
+func Equals(x interface{}) Matcher {
+	v := reflect.ValueOf(x)
+
+	// This matcher doesn't support structs.
+	if v.Kind() == reflect.Struct {
+		panic(fmt.Sprintf("oglematchers.Equals: unsupported kind %v", v.Kind()))
+	}
+
+	// The == operator is not defined for non-nil slices.
+	if v.Kind() == reflect.Slice && v.Pointer() != uintptr(0) {
+		panic(fmt.Sprintf("oglematchers.Equals: non-nil slice"))
+	}
+
+	return &equalsMatcher{v}
+}
+
+type equalsMatcher struct {
+	expectedValue reflect.Value
+}
+
+////////////////////////////////////////////////////////////////////////
+// Numeric types
+////////////////////////////////////////////////////////////////////////
+
+func isSignedInteger(v reflect.Value) bool {
+	k := v.Kind()
+	return k >= reflect.Int && k <= reflect.Int64
+}
+
+func isUnsignedInteger(v reflect.Value) bool {
+	k := v.Kind()
+	return k >= reflect.Uint && k <= reflect.Uintptr
+}
+
+func isInteger(v reflect.Value) bool {
+	return isSignedInteger(v) || isUnsignedInteger(v)
+}
+
+func isFloat(v reflect.Value) bool {
+	k := v.Kind()
+	return k == reflect.Float32 || k == reflect.Float64
+}
+
+func isComplex(v reflect.Value) bool {
+	k := v.Kind()
+	return k == reflect.Complex64 || k == reflect.Complex128
+}
+
+func checkAgainstInt64(e int64, c reflect.Value) (err error) {
+	err = errors.New("")
+
+	switch {
+	case isSignedInteger(c):
+		if c.Int() == e {
+			err = nil
+		}
+
+	case isUnsignedInteger(c):
+		u := c.Uint()
+		if u <= math.MaxInt64 && int64(u) == e {
+			err = nil
+		}
+
+	// Turn around the various floating point types so that the checkAgainst*
+	// functions for them can deal with precision issues.
+	case isFloat(c), isComplex(c):
+		return Equals(c.Interface()).Matches(e)
+
+	default:
+		err = NewFatalError("which is not numeric")
+	}
+
+	return
+}
+
+func checkAgainstUint64(e uint64, c reflect.Value) (err error) {
+	err = errors.New("")
+
+	switch {
+	case isSignedInteger(c):
+		i := c.Int()
+		if i >= 0 && uint64(i) == e {
+			err = nil
+		}
+
+	case isUnsignedInteger(c):
+		if c.Uint() == e {
+			err = nil
+		}
+
+	// Turn around the various floating point types so that the checkAgainst*
+	// functions for them can deal with precision issues.
+	case isFloat(c), isComplex(c):
+		return Equals(c.Interface()).Matches(e)
+
+	default:
+		err = NewFatalError("which is not numeric")
+	}
+
+	return
+}
+
+func checkAgainstFloat32(e float32, c reflect.Value) (err error) {
+	err = errors.New("")
+
+	switch {
+	case isSignedInteger(c):
+		if float32(c.Int()) == e {
+			err = nil
+		}
+
+	case isUnsignedInteger(c):
+		if float32(c.Uint()) == e {
+			err = nil
+		}
+
+	case isFloat(c):
+		// Compare using float32 to avoid a false sense of precision; otherwise
+		// e.g. Equals(float32(0.1)) won't match float32(0.1).
+		if float32(c.Float()) == e {
+			err = nil
+		}
+
+	case isComplex(c):
+		comp := c.Complex()
+		rl := real(comp)
+		im := imag(comp)
+
+		// Compare using float32 to avoid a false sense of precision; otherwise
+		// e.g. Equals(float32(0.1)) won't match (0.1 + 0i).
+		if im == 0 && float32(rl) == e {
+			err = nil
+		}
+
+	default:
+		err = NewFatalError("which is not numeric")
+	}
+
+	return
+}
+
+func checkAgainstFloat64(e float64, c reflect.Value) (err error) {
+	err = errors.New("")
+
+	ck := c.Kind()
+
+	switch {
+	case isSignedInteger(c):
+		if float64(c.Int()) == e {
+			err = nil
+		}
+
+	case isUnsignedInteger(c):
+		if float64(c.Uint()) == e {
+			err = nil
+		}
+
+	// If the actual value is lower precision, turn the comparison around so we
+	// apply the low-precision rules. Otherwise, e.g. Equals(0.1) may not match
+	// float32(0.1).
+	case ck == reflect.Float32 || ck == reflect.Complex64:
+		return Equals(c.Interface()).Matches(e)
+
+		// Otherwise, compare with double precision.
+	case isFloat(c):
+		if c.Float() == e {
+			err = nil
+		}
+
+	case isComplex(c):
+		comp := c.Complex()
+		rl := real(comp)
+		im := imag(comp)
+
+		if im == 0 && rl == e {
+			err = nil
+		}
+
+	default:
+		err = NewFatalError("which is not numeric")
+	}
+
+	return
+}
+
+func checkAgainstComplex64(e complex64, c reflect.Value) (err error) {
+	err = errors.New("")
+	realPart := real(e)
+	imaginaryPart := imag(e)
+
+	switch {
+	case isInteger(c) || isFloat(c):
+		// If we have no imaginary part, then we should just compare against the
+		// real part. Otherwise, we can't be equal.
+		if imaginaryPart != 0 {
+			return
+		}
+
+		return checkAgainstFloat32(realPart, c)
+
+	case isComplex(c):
+		// Compare using complex64 to avoid a false sense of precision; otherwise
+		// e.g. Equals(0.1 + 0i) won't match float32(0.1).
+		if complex64(c.Complex()) == e {
+			err = nil
+		}
+
+	default:
+		err = NewFatalError("which is not numeric")
+	}
+
+	return
+}
+
+func checkAgainstComplex128(e complex128, c reflect.Value) (err error) {
+	err = errors.New("")
+	realPart := real(e)
+	imaginaryPart := imag(e)
+
+	switch {
+	case isInteger(c) || isFloat(c):
+		// If we have no imaginary part, then we should just compare against the
+		// real part. Otherwise, we can't be equal.
+		if imaginaryPart != 0 {
+			return
+		}
+
+		return checkAgainstFloat64(realPart, c)
+
+	case isComplex(c):
+		if c.Complex() == e {
+			err = nil
+		}
+
+	default:
+		err = NewFatalError("which is not numeric")
+	}
+
+	return
+}
+
+////////////////////////////////////////////////////////////////////////
+// Other types
+////////////////////////////////////////////////////////////////////////
+
+func checkAgainstBool(e bool, c reflect.Value) (err error) {
+	if c.Kind() != reflect.Bool {
+		err = NewFatalError("which is not a bool")
+		return
+	}
+
+	err = errors.New("")
+	if c.Bool() == e {
+		err = nil
+	}
+	return
+}
+
+func checkAgainstChan(e reflect.Value, c reflect.Value) (err error) {
+	// Create a description of e's type, e.g. "chan int".
+	typeStr := fmt.Sprintf("%s %s", e.Type().ChanDir(), e.Type().Elem())
+
+	// Make sure c is a chan of the correct type.
+	if c.Kind() != reflect.Chan ||
+		c.Type().ChanDir() != e.Type().ChanDir() ||
+		c.Type().Elem() != e.Type().Elem() {
+		err = NewFatalError(fmt.Sprintf("which is not a %s", typeStr))
+		return
+	}
+
+	err = errors.New("")
+	if c.Pointer() == e.Pointer() {
+		err = nil
+	}
+	return
+}
+
+func checkAgainstFunc(e reflect.Value, c reflect.Value) (err error) {
+	// Make sure c is a function.
+	if c.Kind() != reflect.Func {
+		err = NewFatalError("which is not a function")
+		return
+	}
+
+	err = errors.New("")
+	if c.Pointer() == e.Pointer() {
+		err = nil
+	}
+	return
+}
+
+func checkAgainstMap(e reflect.Value, c reflect.Value) (err error) {
+	// Make sure c is a map.
+	if c.Kind() != reflect.Map {
+		err = NewFatalError("which is not a map")
+		return
+	}
+
+	err = errors.New("")
+	if c.Pointer() == e.Pointer() {
+		err = nil
+	}
+	return
+}
+
+func checkAgainstPtr(e reflect.Value, c reflect.Value) (err error) {
+	// Create a description of e's type, e.g. "*int".
+	typeStr := fmt.Sprintf("*%v", e.Type().Elem())
+
+	// Make sure c is a pointer of the correct type.
+	if c.Kind() != reflect.Ptr ||
+		c.Type().Elem() != e.Type().Elem() {
+		err = NewFatalError(fmt.Sprintf("which is not a %s", typeStr))
+		return
+	}
+
+	err = errors.New("")
+	if c.Pointer() == e.Pointer() {
+		err = nil
+	}
+	return
+}
+
+func checkAgainstSlice(e reflect.Value, c reflect.Value) (err error) {
+	// Create a description of e's type, e.g. "[]int".
+	typeStr := fmt.Sprintf("[]%v", e.Type().Elem())
+
+	// Make sure c is a slice of the correct type.
+	if c.Kind() != reflect.Slice ||
+		c.Type().Elem() != e.Type().Elem() {
+		err = NewFatalError(fmt.Sprintf("which is not a %s", typeStr))
+		return
+	}
+
+	err = errors.New("")
+	if c.Pointer() == e.Pointer() {
+		err = nil
+	}
+	return
+}
+
+func checkAgainstString(e reflect.Value, c reflect.Value) (err error) {
+	// Make sure c is a string.
+	if c.Kind() != reflect.String {
+		err = NewFatalError("which is not a string")
+		return
+	}
+
+	err = errors.New("")
+	if c.String() == e.String() {
+		err = nil
+	}
+	return
+}
+
+func checkAgainstArray(e reflect.Value, c reflect.Value) (err error) {
+	// Create a description of e's type, e.g. "[2]int".
+	typeStr := fmt.Sprintf("%v", e.Type())
+
+	// Make sure c is the correct type.
+	if c.Type() != e.Type() {
+		err = NewFatalError(fmt.Sprintf("which is not %s", typeStr))
+		return
+	}
+
+	// Check for equality.
+	if e.Interface() != c.Interface() {
+		err = errors.New("")
+		return
+	}
+
+	return
+}
+
+func checkAgainstUnsafePointer(e reflect.Value, c reflect.Value) (err error) {
+	// Make sure c is a pointer.
+	if c.Kind() != reflect.UnsafePointer {
+		err = NewFatalError("which is not a unsafe.Pointer")
+		return
+	}
+
+	err = errors.New("")
+	if c.Pointer() == e.Pointer() {
+		err = nil
+	}
+	return
+}
+
+func checkForNil(c reflect.Value) (err error) {
+	err = errors.New("")
+
+	// Make sure it is legal to call IsNil.
+	switch c.Kind() {
+	case reflect.Invalid:
+	case reflect.Chan:
+	case reflect.Func:
+	case reflect.Interface:
+	case reflect.Map:
+	case reflect.Ptr:
+	case reflect.Slice:
+
+	default:
+		err = NewFatalError("which cannot be compared to nil")
+		return
+	}
+
+	// Ask whether the value is nil. Handle a nil literal (kind Invalid)
+	// specially, since it's not legal to call IsNil there.
+	if c.Kind() == reflect.Invalid || c.IsNil() {
+		err = nil
+	}
+	return
+}
+
+////////////////////////////////////////////////////////////////////////
+// Public implementation
+////////////////////////////////////////////////////////////////////////
+
+func (m *equalsMatcher) Matches(candidate interface{}) error {
+	e := m.expectedValue
+	c := reflect.ValueOf(candidate)
+	ek := e.Kind()
+
+	switch {
+	case ek == reflect.Bool:
+		return checkAgainstBool(e.Bool(), c)
+
+	case isSignedInteger(e):
+		return checkAgainstInt64(e.Int(), c)
+
+	case isUnsignedInteger(e):
+		return checkAgainstUint64(e.Uint(), c)
+
+	case ek == reflect.Float32:
+		return checkAgainstFloat32(float32(e.Float()), c)
+
+	case ek == reflect.Float64:
+		return checkAgainstFloat64(e.Float(), c)
+
+	case ek == reflect.Complex64:
+		return checkAgainstComplex64(complex64(e.Complex()), c)
+
+	case ek == reflect.Complex128:
+		return checkAgainstComplex128(complex128(e.Complex()), c)
+
+	case ek == reflect.Chan:
+		return checkAgainstChan(e, c)
+
+	case ek == reflect.Func:
+		return checkAgainstFunc(e, c)
+
+	case ek == reflect.Map:
+		return checkAgainstMap(e, c)
+
+	case ek == reflect.Ptr:
+		return checkAgainstPtr(e, c)
+
+	case ek == reflect.Slice:
+		return checkAgainstSlice(e, c)
+
+	case ek == reflect.String:
+		return checkAgainstString(e, c)
+
+	case ek == reflect.Array:
+		return checkAgainstArray(e, c)
+
+	case ek == reflect.UnsafePointer:
+		return checkAgainstUnsafePointer(e, c)
+
+	case ek == reflect.Invalid:
+		return checkForNil(c)
+	}
+
+	panic(fmt.Sprintf("equalsMatcher.Matches: unexpected kind: %v", ek))
+}
+
+func (m *equalsMatcher) Description() string {
+	// Special case: handle nil.
+	if !m.expectedValue.IsValid() {
+		return "is nil"
+	}
+
+	return fmt.Sprintf("%v", m.expectedValue.Interface())
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/greater_or_equal.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/greater_or_equal.go
@@ -1,0 +1,39 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// GreaterOrEqual returns a matcher that matches integer, floating point, or
+// strings values v such that v >= x. Comparison is not defined between numeric
+// and string types, but is defined between all integer and floating point
+// types.
+//
+// x must itself be an integer, floating point, or string type; otherwise,
+// GreaterOrEqual will panic.
+func GreaterOrEqual(x interface{}) Matcher {
+	desc := fmt.Sprintf("greater than or equal to %v", x)
+
+	// Special case: make it clear that strings are strings.
+	if reflect.TypeOf(x).Kind() == reflect.String {
+		desc = fmt.Sprintf("greater than or equal to \"%s\"", x)
+	}
+
+	return transformDescription(Not(LessThan(x)), desc)
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/greater_than.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/greater_than.go
@@ -1,0 +1,39 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// GreaterThan returns a matcher that matches integer, floating point, or
+// strings values v such that v > x. Comparison is not defined between numeric
+// and string types, but is defined between all integer and floating point
+// types.
+//
+// x must itself be an integer, floating point, or string type; otherwise,
+// GreaterThan will panic.
+func GreaterThan(x interface{}) Matcher {
+	desc := fmt.Sprintf("greater than %v", x)
+
+	// Special case: make it clear that strings are strings.
+	if reflect.TypeOf(x).Kind() == reflect.String {
+		desc = fmt.Sprintf("greater than \"%s\"", x)
+	}
+
+	return transformDescription(Not(LessOrEqual(x)), desc)
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/less_or_equal.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/less_or_equal.go
@@ -1,0 +1,41 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// LessOrEqual returns a matcher that matches integer, floating point, or
+// strings values v such that v <= x. Comparison is not defined between numeric
+// and string types, but is defined between all integer and floating point
+// types.
+//
+// x must itself be an integer, floating point, or string type; otherwise,
+// LessOrEqual will panic.
+func LessOrEqual(x interface{}) Matcher {
+	desc := fmt.Sprintf("less than or equal to %v", x)
+
+	// Special case: make it clear that strings are strings.
+	if reflect.TypeOf(x).Kind() == reflect.String {
+		desc = fmt.Sprintf("less than or equal to \"%s\"", x)
+	}
+
+	// Put LessThan last so that its error messages will be used in the event of
+	// failure.
+	return transformDescription(AnyOf(Equals(x), LessThan(x)), desc)
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/less_than.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/less_than.go
@@ -1,0 +1,152 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+)
+
+// LessThan returns a matcher that matches integer, floating point, or strings
+// values v such that v < x. Comparison is not defined between numeric and
+// string types, but is defined between all integer and floating point types.
+//
+// x must itself be an integer, floating point, or string type; otherwise,
+// LessThan will panic.
+func LessThan(x interface{}) Matcher {
+	v := reflect.ValueOf(x)
+	kind := v.Kind()
+
+	switch {
+	case isInteger(v):
+	case isFloat(v):
+	case kind == reflect.String:
+
+	default:
+		panic(fmt.Sprintf("LessThan: unexpected kind %v", kind))
+	}
+
+	return &lessThanMatcher{v}
+}
+
+type lessThanMatcher struct {
+	limit reflect.Value
+}
+
+func (m *lessThanMatcher) Description() string {
+	// Special case: make it clear that strings are strings.
+	if m.limit.Kind() == reflect.String {
+		return fmt.Sprintf("less than \"%s\"", m.limit.String())
+	}
+
+	return fmt.Sprintf("less than %v", m.limit.Interface())
+}
+
+func compareIntegers(v1, v2 reflect.Value) (err error) {
+	err = errors.New("")
+
+	switch {
+	case isSignedInteger(v1) && isSignedInteger(v2):
+		if v1.Int() < v2.Int() {
+			err = nil
+		}
+		return
+
+	case isSignedInteger(v1) && isUnsignedInteger(v2):
+		if v1.Int() < 0 || uint64(v1.Int()) < v2.Uint() {
+			err = nil
+		}
+		return
+
+	case isUnsignedInteger(v1) && isSignedInteger(v2):
+		if v1.Uint() <= math.MaxInt64 && int64(v1.Uint()) < v2.Int() {
+			err = nil
+		}
+		return
+
+	case isUnsignedInteger(v1) && isUnsignedInteger(v2):
+		if v1.Uint() < v2.Uint() {
+			err = nil
+		}
+		return
+	}
+
+	panic(fmt.Sprintf("compareIntegers: %v %v", v1, v2))
+}
+
+func getFloat(v reflect.Value) float64 {
+	switch {
+	case isSignedInteger(v):
+		return float64(v.Int())
+
+	case isUnsignedInteger(v):
+		return float64(v.Uint())
+
+	case isFloat(v):
+		return v.Float()
+	}
+
+	panic(fmt.Sprintf("getFloat: %v", v))
+}
+
+func (m *lessThanMatcher) Matches(c interface{}) (err error) {
+	v1 := reflect.ValueOf(c)
+	v2 := m.limit
+
+	err = errors.New("")
+
+	// Handle strings as a special case.
+	if v1.Kind() == reflect.String && v2.Kind() == reflect.String {
+		if v1.String() < v2.String() {
+			err = nil
+		}
+		return
+	}
+
+	// If we get here, we require that we are dealing with integers or floats.
+	v1Legal := isInteger(v1) || isFloat(v1)
+	v2Legal := isInteger(v2) || isFloat(v2)
+	if !v1Legal || !v2Legal {
+		err = NewFatalError("which is not comparable")
+		return
+	}
+
+	// Handle the various comparison cases.
+	switch {
+	// Both integers
+	case isInteger(v1) && isInteger(v2):
+		return compareIntegers(v1, v2)
+
+	// At least one float32
+	case v1.Kind() == reflect.Float32 || v2.Kind() == reflect.Float32:
+		if float32(getFloat(v1)) < float32(getFloat(v2)) {
+			err = nil
+		}
+		return
+
+	// At least one float64
+	case v1.Kind() == reflect.Float64 || v2.Kind() == reflect.Float64:
+		if getFloat(v1) < getFloat(v2) {
+			err = nil
+		}
+		return
+	}
+
+	// We shouldn't get here.
+	panic(fmt.Sprintf("lessThanMatcher.Matches: Shouldn't get here: %v %v", v1, v2))
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/matcher.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/matcher.go
@@ -1,0 +1,86 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package oglematchers provides a set of matchers useful in a testing or
+// mocking framework. These matchers are inspired by and mostly compatible with
+// Google Test for C++ and Google JS Test.
+//
+// This package is used by github.com/smartystreets/assertions/internal/ogletest and
+// github.com/smartystreets/assertions/internal/oglemock, which may be more directly useful if you're not
+// writing your own testing package or defining your own matchers.
+package oglematchers
+
+// A Matcher is some predicate implicitly defining a set of values that it
+// matches. For example, GreaterThan(17) matches all numeric values greater
+// than 17, and HasSubstr("taco") matches all strings with the substring
+// "taco".
+//
+// Matchers are typically exposed to tests via constructor functions like
+// HasSubstr. In order to implement such a function you can either define your
+// own matcher type or use NewMatcher.
+type Matcher interface {
+	// Check whether the supplied value belongs to the the set defined by the
+	// matcher. Return a non-nil error if and only if it does not.
+	//
+	// The error describes why the value doesn't match. The error text is a
+	// relative clause that is suitable for being placed after the value. For
+	// example, a predicate that matches strings with a particular substring may,
+	// when presented with a numerical value, return the following error text:
+	//
+	//     "which is not a string"
+	//
+	// Then the failure message may look like:
+	//
+	//     Expected: has substring "taco"
+	//     Actual:   17, which is not a string
+	//
+	// If the error is self-apparent based on the description of the matcher, the
+	// error text may be empty (but the error still non-nil). For example:
+	//
+	//     Expected: 17
+	//     Actual:   19
+	//
+	// If you are implementing a new matcher, see also the documentation on
+	// FatalError.
+	Matches(candidate interface{}) error
+
+	// Description returns a string describing the property that values matching
+	// this matcher have, as a verb phrase where the subject is the value. For
+	// example, "is greather than 17" or "has substring "taco"".
+	Description() string
+}
+
+// FatalError is an implementation of the error interface that may be returned
+// from matchers, indicating the error should be propagated. Returning a
+// *FatalError indicates that the matcher doesn't process values of the
+// supplied type, or otherwise doesn't know how to handle the value.
+//
+// For example, if GreaterThan(17) returned false for the value "taco" without
+// a fatal error, then Not(GreaterThan(17)) would return true. This is
+// technically correct, but is surprising and may mask failures where the wrong
+// sort of matcher is accidentally used. Instead, GreaterThan(17) can return a
+// fatal error, which will be propagated by Not().
+type FatalError struct {
+	errorText string
+}
+
+// NewFatalError creates a FatalError struct with the supplied error text.
+func NewFatalError(s string) *FatalError {
+	return &FatalError{s}
+}
+
+func (e *FatalError) Error() string {
+	return e.errorText
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/not.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/not.go
@@ -1,0 +1,53 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Not returns a matcher that inverts the set of values matched by the wrapped
+// matcher. It does not transform the result for values for which the wrapped
+// matcher returns a fatal error.
+func Not(m Matcher) Matcher {
+	return &notMatcher{m}
+}
+
+type notMatcher struct {
+	wrapped Matcher
+}
+
+func (m *notMatcher) Matches(c interface{}) (err error) {
+	err = m.wrapped.Matches(c)
+
+	// Did the wrapped matcher say yes?
+	if err == nil {
+		return errors.New("")
+	}
+
+	// Did the wrapped matcher return a fatal error?
+	if _, isFatal := err.(*FatalError); isFatal {
+		return err
+	}
+
+	// The wrapped matcher returned a non-fatal error.
+	return nil
+}
+
+func (m *notMatcher) Description() string {
+	return fmt.Sprintf("not(%s)", m.wrapped.Description())
+}

--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/transform_description.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/transform_description.go
@@ -1,0 +1,36 @@
+// Copyright 2011 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oglematchers
+
+// transformDescription returns a matcher that is equivalent to the supplied
+// one, except that it has the supplied description instead of the one attached
+// to the existing matcher.
+func transformDescription(m Matcher, newDesc string) Matcher {
+	return &transformDescriptionMatcher{newDesc, m}
+}
+
+type transformDescriptionMatcher struct {
+	desc           string
+	wrappedMatcher Matcher
+}
+
+func (m *transformDescriptionMatcher) Description() string {
+	return m.desc
+}
+
+func (m *transformDescriptionMatcher) Matches(c interface{}) error {
+	return m.wrappedMatcher.Matches(c)
+}

--- a/vendor/github.com/smartystreets/assertions/messages.go
+++ b/vendor/github.com/smartystreets/assertions/messages.go
@@ -1,0 +1,93 @@
+package assertions
+
+const ( // equality
+	shouldHaveBeenEqual             = "Expected: '%v'\nActual:   '%v'\n(Should be equal)"
+	shouldNotHaveBeenEqual          = "Expected     '%v'\nto NOT equal '%v'\n(but it did)!"
+	shouldHaveBeenEqualTypeMismatch = "Expected: '%v' (%T)\nActual:   '%v' (%T)\n(Should be equal, type mismatch)"
+	shouldHaveBeenAlmostEqual       = "Expected '%v' to almost equal '%v' (but it didn't)!"
+	shouldHaveNotBeenAlmostEqual    = "Expected '%v' to NOT almost equal '%v' (but it did)!"
+	shouldHaveResembled             = "Expected: '%s'\nActual:   '%s'\n(Should resemble)!"
+	shouldNotHaveResembled          = "Expected        '%#v'\nto NOT resemble '%#v'\n(but it did)!"
+	shouldBePointers                = "Both arguments should be pointers "
+	shouldHaveBeenNonNilPointer     = shouldBePointers + "(the %s was %s)!"
+	shouldHavePointedTo             = "Expected '%+v' (address: '%v') and '%+v' (address: '%v') to be the same address (but their weren't)!"
+	shouldNotHavePointedTo          = "Expected '%+v' and '%+v' to be different references (but they matched: '%v')!"
+	shouldHaveBeenNil               = "Expected: nil\nActual:   '%v'"
+	shouldNotHaveBeenNil            = "Expected '%+v' to NOT be nil (but it was)!"
+	shouldHaveBeenTrue              = "Expected: true\nActual:   %v"
+	shouldHaveBeenFalse             = "Expected: false\nActual:   %v"
+	shouldHaveBeenZeroValue         = "'%+v' should have been the zero value" //"Expected: (zero value)\nActual:   %v"
+)
+
+const ( // quantity comparisons
+	shouldHaveBeenGreater            = "Expected '%v' to be greater than '%v' (but it wasn't)!"
+	shouldHaveBeenGreaterOrEqual     = "Expected '%v' to be greater than or equal to '%v' (but it wasn't)!"
+	shouldHaveBeenLess               = "Expected '%v' to be less than '%v' (but it wasn't)!"
+	shouldHaveBeenLessOrEqual        = "Expected '%v' to be less than or equal to '%v' (but it wasn't)!"
+	shouldHaveBeenBetween            = "Expected '%v' to be between '%v' and '%v' (but it wasn't)!"
+	shouldNotHaveBeenBetween         = "Expected '%v' NOT to be between '%v' and '%v' (but it was)!"
+	shouldHaveDifferentUpperAndLower = "The lower and upper bounds must be different values (they were both '%v')."
+	shouldHaveBeenBetweenOrEqual     = "Expected '%v' to be between '%v' and '%v' or equal to one of them (but it wasn't)!"
+	shouldNotHaveBeenBetweenOrEqual  = "Expected '%v' NOT to be between '%v' and '%v' or equal to one of them (but it was)!"
+)
+
+const ( // collections
+	shouldHaveContained            = "Expected the container (%v) to contain: '%v' (but it didn't)!"
+	shouldNotHaveContained         = "Expected the container (%v) NOT to contain: '%v' (but it did)!"
+	shouldHaveContainedKey         = "Expected the %v to contain the key: %v (but it didn't)!"
+	shouldNotHaveContainedKey      = "Expected the %v NOT to contain the key: %v (but it did)!"
+	shouldHaveBeenIn               = "Expected '%v' to be in the container (%v), but it wasn't!"
+	shouldNotHaveBeenIn            = "Expected '%v' NOT to be in the container (%v), but it was!"
+	shouldHaveBeenAValidCollection = "You must provide a valid container (was %v)!"
+	shouldHaveBeenAValidMap        = "You must provide a valid map type (was %v)!"
+	shouldHaveBeenEmpty            = "Expected %+v to be empty (but it wasn't)!"
+	shouldNotHaveBeenEmpty         = "Expected %+v to NOT be empty (but it was)!"
+	shouldHaveBeenAValidInteger    = "You must provide a valid integer (was %v)!"
+	shouldHaveBeenAValidLength     = "You must provide a valid positive integer (was %v)!"
+	shouldHaveHadLength            = "Expected %+v (length: %v) to have length equal to '%v', but it wasn't!"
+)
+
+const ( // strings
+	shouldHaveStartedWith           = "Expected      '%v'\nto start with '%v'\n(but it didn't)!"
+	shouldNotHaveStartedWith        = "Expected          '%v'\nNOT to start with '%v'\n(but it did)!"
+	shouldHaveEndedWith             = "Expected    '%v'\nto end with '%v'\n(but it didn't)!"
+	shouldNotHaveEndedWith          = "Expected        '%v'\nNOT to end with '%v'\n(but it did)!"
+	shouldAllBeStrings              = "All arguments to this assertion must be strings (you provided: %v)."
+	shouldBothBeStrings             = "Both arguments to this assertion must be strings (you provided %v and %v)."
+	shouldBeString                  = "The argument to this assertion must be a string (you provided %v)."
+	shouldHaveContainedSubstring    = "Expected '%s' to contain substring '%s' (but it didn't)!"
+	shouldNotHaveContainedSubstring = "Expected '%s' NOT to contain substring '%s' (but it did)!"
+	shouldHaveBeenBlank             = "Expected '%s' to be blank (but it wasn't)!"
+	shouldNotHaveBeenBlank          = "Expected value to NOT be blank (but it was)!"
+)
+
+const ( // panics
+	shouldUseVoidNiladicFunction = "You must provide a void, niladic function as the first argument!"
+	shouldHavePanickedWith       = "Expected func() to panic with '%v' (but it panicked with '%v')!"
+	shouldHavePanicked           = "Expected func() to panic (but it didn't)!"
+	shouldNotHavePanicked        = "Expected func() NOT to panic (error: '%+v')!"
+	shouldNotHavePanickedWith    = "Expected func() NOT to panic with '%v' (but it did)!"
+)
+
+const ( // type checking
+	shouldHaveBeenA    = "Expected '%v' to be: '%v' (but was: '%v')!"
+	shouldNotHaveBeenA = "Expected '%v' to NOT be: '%v' (but it was)!"
+
+	shouldHaveImplemented             = "Expected: '%v interface support'\nActual:   '%v' does not implement the interface!"
+	shouldNotHaveImplemented          = "Expected         '%v'\nto NOT implement '%v'\n(but it did)!"
+	shouldCompareWithInterfacePointer = "The expected value must be a pointer to an interface type (eg. *fmt.Stringer)"
+	shouldNotBeNilActual              = "The actual value was 'nil' and should be a value or a pointer to a value!"
+)
+
+const ( // time comparisons
+	shouldUseTimes                   = "You must provide time instances as arguments to this assertion."
+	shouldUseTimeSlice               = "You must provide a slice of time instances as the first argument to this assertion."
+	shouldUseDurationAndTime         = "You must provide a duration and a time as arguments to this assertion."
+	shouldHaveHappenedBefore         = "Expected '%v' to happen before '%v' (it happened '%v' after)!"
+	shouldHaveHappenedAfter          = "Expected '%v' to happen after '%v' (it happened '%v' before)!"
+	shouldHaveHappenedBetween        = "Expected '%v' to happen between '%v' and '%v' (it happened '%v' outside threshold)!"
+	shouldNotHaveHappenedOnOrBetween = "Expected '%v' to NOT happen on or between '%v' and '%v' (but it did)!"
+
+	// format params: incorrect-index, previous-index, previous-time, incorrect-index, incorrect-time
+	shouldHaveBeenChronological = "The 'Time' at index [%d] should have happened after the previous one (but it didn't!):\n  [%d]: %s\n  [%d]: %s (see, it happened before!)"
+)

--- a/vendor/github.com/smartystreets/assertions/panic.go
+++ b/vendor/github.com/smartystreets/assertions/panic.go
@@ -1,0 +1,115 @@
+package assertions
+
+import "fmt"
+
+// ShouldPanic receives a void, niladic function and expects to recover a panic.
+func ShouldPanic(actual interface{}, expected ...interface{}) (message string) {
+	if fail := need(0, expected); fail != success {
+		return fail
+	}
+
+	action, _ := actual.(func())
+
+	if action == nil {
+		message = shouldUseVoidNiladicFunction
+		return
+	}
+
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			message = shouldHavePanicked
+		} else {
+			message = success
+		}
+	}()
+	action()
+
+	return
+}
+
+// ShouldNotPanic receives a void, niladic function and expects to execute the function without any panic.
+func ShouldNotPanic(actual interface{}, expected ...interface{}) (message string) {
+	if fail := need(0, expected); fail != success {
+		return fail
+	}
+
+	action, _ := actual.(func())
+
+	if action == nil {
+		message = shouldUseVoidNiladicFunction
+		return
+	}
+
+	defer func() {
+		recovered := recover()
+		if recovered != nil {
+			message = fmt.Sprintf(shouldNotHavePanicked, recovered)
+		} else {
+			message = success
+		}
+	}()
+	action()
+
+	return
+}
+
+// ShouldPanicWith receives a void, niladic function and expects to recover a panic with the second argument as the content.
+func ShouldPanicWith(actual interface{}, expected ...interface{}) (message string) {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	action, _ := actual.(func())
+
+	if action == nil {
+		message = shouldUseVoidNiladicFunction
+		return
+	}
+
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			message = shouldHavePanicked
+		} else {
+			if equal := ShouldEqual(recovered, expected[0]); equal != success {
+				message = serializer.serialize(expected[0], recovered, fmt.Sprintf(shouldHavePanickedWith, expected[0], recovered))
+			} else {
+				message = success
+			}
+		}
+	}()
+	action()
+
+	return
+}
+
+// ShouldNotPanicWith receives a void, niladic function and expects to recover a panic whose content differs from the second argument.
+func ShouldNotPanicWith(actual interface{}, expected ...interface{}) (message string) {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	action, _ := actual.(func())
+
+	if action == nil {
+		message = shouldUseVoidNiladicFunction
+		return
+	}
+
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			message = success
+		} else {
+			if equal := ShouldEqual(recovered, expected[0]); equal == success {
+				message = fmt.Sprintf(shouldNotHavePanickedWith, expected[0])
+			} else {
+				message = success
+			}
+		}
+	}()
+	action()
+
+	return
+}

--- a/vendor/github.com/smartystreets/assertions/panic_test.go
+++ b/vendor/github.com/smartystreets/assertions/panic_test.go
@@ -1,0 +1,53 @@
+package assertions
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestShouldPanic(t *testing.T) {
+	fail(t, so(func() {}, ShouldPanic, 1), "This assertion requires exactly 0 comparison values (you provided 1).")
+	fail(t, so(func() {}, ShouldPanic, 1, 2, 3), "This assertion requires exactly 0 comparison values (you provided 3).")
+
+	fail(t, so(1, ShouldPanic), shouldUseVoidNiladicFunction)
+	fail(t, so(func(i int) {}, ShouldPanic), shouldUseVoidNiladicFunction)
+	fail(t, so(func() int { panic("hi") }, ShouldPanic), shouldUseVoidNiladicFunction)
+
+	fail(t, so(func() {}, ShouldPanic), shouldHavePanicked)
+	pass(t, so(func() { panic("hi") }, ShouldPanic))
+}
+
+func TestShouldNotPanic(t *testing.T) {
+	fail(t, so(func() {}, ShouldNotPanic, 1), "This assertion requires exactly 0 comparison values (you provided 1).")
+	fail(t, so(func() {}, ShouldNotPanic, 1, 2, 3), "This assertion requires exactly 0 comparison values (you provided 3).")
+
+	fail(t, so(1, ShouldNotPanic), shouldUseVoidNiladicFunction)
+	fail(t, so(func(i int) {}, ShouldNotPanic), shouldUseVoidNiladicFunction)
+
+	fail(t, so(func() { panic("hi") }, ShouldNotPanic), fmt.Sprintf(shouldNotHavePanicked, "hi"))
+	pass(t, so(func() {}, ShouldNotPanic))
+}
+
+func TestShouldPanicWith(t *testing.T) {
+	fail(t, so(func() {}, ShouldPanicWith), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(func() {}, ShouldPanicWith, 1, 2, 3), "This assertion requires exactly 1 comparison values (you provided 3).")
+
+	fail(t, so(1, ShouldPanicWith, 1), shouldUseVoidNiladicFunction)
+	fail(t, so(func(i int) {}, ShouldPanicWith, "hi"), shouldUseVoidNiladicFunction)
+	fail(t, so(func() {}, ShouldPanicWith, "bye"), shouldHavePanicked)
+	fail(t, so(func() { panic("hi") }, ShouldPanicWith, "bye"), "bye|hi|Expected func() to panic with 'bye' (but it panicked with 'hi')!")
+
+	pass(t, so(func() { panic("hi") }, ShouldPanicWith, "hi"))
+}
+
+func TestShouldNotPanicWith(t *testing.T) {
+	fail(t, so(func() {}, ShouldNotPanicWith), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(func() {}, ShouldNotPanicWith, 1, 2, 3), "This assertion requires exactly 1 comparison values (you provided 3).")
+
+	fail(t, so(1, ShouldNotPanicWith, 1), shouldUseVoidNiladicFunction)
+	fail(t, so(func(i int) {}, ShouldNotPanicWith, "hi"), shouldUseVoidNiladicFunction)
+	fail(t, so(func() { panic("hi") }, ShouldNotPanicWith, "hi"), "Expected func() NOT to panic with 'hi' (but it did)!")
+
+	pass(t, so(func() {}, ShouldNotPanicWith, "bye"))
+	pass(t, so(func() { panic("hi") }, ShouldNotPanicWith, "bye"))
+}

--- a/vendor/github.com/smartystreets/assertions/quantity.go
+++ b/vendor/github.com/smartystreets/assertions/quantity.go
@@ -1,0 +1,141 @@
+package assertions
+
+import (
+	"fmt"
+
+	"github.com/smartystreets/assertions/internal/oglematchers"
+)
+
+// ShouldBeGreaterThan receives exactly two parameters and ensures that the first is greater than the second.
+func ShouldBeGreaterThan(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	if matchError := oglematchers.GreaterThan(expected[0]).Matches(actual); matchError != nil {
+		return fmt.Sprintf(shouldHaveBeenGreater, actual, expected[0])
+	}
+	return success
+}
+
+// ShouldBeGreaterThanOrEqualTo receives exactly two parameters and ensures that the first is greater than or equal to the second.
+func ShouldBeGreaterThanOrEqualTo(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	} else if matchError := oglematchers.GreaterOrEqual(expected[0]).Matches(actual); matchError != nil {
+		return fmt.Sprintf(shouldHaveBeenGreaterOrEqual, actual, expected[0])
+	}
+	return success
+}
+
+// ShouldBeLessThan receives exactly two parameters and ensures that the first is less than the second.
+func ShouldBeLessThan(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	} else if matchError := oglematchers.LessThan(expected[0]).Matches(actual); matchError != nil {
+		return fmt.Sprintf(shouldHaveBeenLess, actual, expected[0])
+	}
+	return success
+}
+
+// ShouldBeLessThan receives exactly two parameters and ensures that the first is less than or equal to the second.
+func ShouldBeLessThanOrEqualTo(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	} else if matchError := oglematchers.LessOrEqual(expected[0]).Matches(actual); matchError != nil {
+		return fmt.Sprintf(shouldHaveBeenLessOrEqual, actual, expected[0])
+	}
+	return success
+}
+
+// ShouldBeBetween receives exactly three parameters: an actual value, a lower bound, and an upper bound.
+// It ensures that the actual value is between both bounds (but not equal to either of them).
+func ShouldBeBetween(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	lower, upper, fail := deriveBounds(expected)
+
+	if fail != success {
+		return fail
+	} else if !isBetween(actual, lower, upper) {
+		return fmt.Sprintf(shouldHaveBeenBetween, actual, lower, upper)
+	}
+	return success
+}
+
+// ShouldNotBeBetween receives exactly three parameters: an actual value, a lower bound, and an upper bound.
+// It ensures that the actual value is NOT between both bounds.
+func ShouldNotBeBetween(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	lower, upper, fail := deriveBounds(expected)
+
+	if fail != success {
+		return fail
+	} else if isBetween(actual, lower, upper) {
+		return fmt.Sprintf(shouldNotHaveBeenBetween, actual, lower, upper)
+	}
+	return success
+}
+func deriveBounds(values []interface{}) (lower interface{}, upper interface{}, fail string) {
+	lower = values[0]
+	upper = values[1]
+
+	if ShouldNotEqual(lower, upper) != success {
+		return nil, nil, fmt.Sprintf(shouldHaveDifferentUpperAndLower, lower)
+	} else if ShouldBeLessThan(lower, upper) != success {
+		lower, upper = upper, lower
+	}
+	return lower, upper, success
+}
+func isBetween(value, lower, upper interface{}) bool {
+	if ShouldBeGreaterThan(value, lower) != success {
+		return false
+	} else if ShouldBeLessThan(value, upper) != success {
+		return false
+	}
+	return true
+}
+
+// ShouldBeBetweenOrEqual receives exactly three parameters: an actual value, a lower bound, and an upper bound.
+// It ensures that the actual value is between both bounds or equal to one of them.
+func ShouldBeBetweenOrEqual(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	lower, upper, fail := deriveBounds(expected)
+
+	if fail != success {
+		return fail
+	} else if !isBetweenOrEqual(actual, lower, upper) {
+		return fmt.Sprintf(shouldHaveBeenBetweenOrEqual, actual, lower, upper)
+	}
+	return success
+}
+
+// ShouldNotBeBetweenOrEqual receives exactly three parameters: an actual value, a lower bound, and an upper bound.
+// It ensures that the actual value is nopt between the bounds nor equal to either of them.
+func ShouldNotBeBetweenOrEqual(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	lower, upper, fail := deriveBounds(expected)
+
+	if fail != success {
+		return fail
+	} else if isBetweenOrEqual(actual, lower, upper) {
+		return fmt.Sprintf(shouldNotHaveBeenBetweenOrEqual, actual, lower, upper)
+	}
+	return success
+}
+
+func isBetweenOrEqual(value, lower, upper interface{}) bool {
+	if ShouldBeGreaterThanOrEqualTo(value, lower) != success {
+		return false
+	} else if ShouldBeLessThanOrEqualTo(value, upper) != success {
+		return false
+	}
+	return true
+}

--- a/vendor/github.com/smartystreets/assertions/quantity_test.go
+++ b/vendor/github.com/smartystreets/assertions/quantity_test.go
@@ -1,0 +1,145 @@
+package assertions
+
+import "testing"
+
+func TestShouldBeGreaterThan(t *testing.T) {
+	fail(t, so(1, ShouldBeGreaterThan), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(1, ShouldBeGreaterThan, 0, 0), "This assertion requires exactly 1 comparison values (you provided 2).")
+
+	pass(t, so(1, ShouldBeGreaterThan, 0))
+	pass(t, so(1.1, ShouldBeGreaterThan, 1))
+	pass(t, so(1, ShouldBeGreaterThan, uint(0)))
+	pass(t, so("b", ShouldBeGreaterThan, "a"))
+
+	fail(t, so(0, ShouldBeGreaterThan, 1), "Expected '0' to be greater than '1' (but it wasn't)!")
+	fail(t, so(1, ShouldBeGreaterThan, 1.1), "Expected '1' to be greater than '1.1' (but it wasn't)!")
+	fail(t, so(uint(0), ShouldBeGreaterThan, 1.1), "Expected '0' to be greater than '1.1' (but it wasn't)!")
+	fail(t, so("a", ShouldBeGreaterThan, "b"), "Expected 'a' to be greater than 'b' (but it wasn't)!")
+}
+
+func TestShouldBeGreaterThanOrEqual(t *testing.T) {
+	fail(t, so(1, ShouldBeGreaterThanOrEqualTo), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(1, ShouldBeGreaterThanOrEqualTo, 0, 0), "This assertion requires exactly 1 comparison values (you provided 2).")
+
+	pass(t, so(1, ShouldBeGreaterThanOrEqualTo, 1))
+	pass(t, so(1.1, ShouldBeGreaterThanOrEqualTo, 1.1))
+	pass(t, so(1, ShouldBeGreaterThanOrEqualTo, uint(1)))
+	pass(t, so("b", ShouldBeGreaterThanOrEqualTo, "b"))
+
+	pass(t, so(1, ShouldBeGreaterThanOrEqualTo, 0))
+	pass(t, so(1.1, ShouldBeGreaterThanOrEqualTo, 1))
+	pass(t, so(1, ShouldBeGreaterThanOrEqualTo, uint(0)))
+	pass(t, so("b", ShouldBeGreaterThanOrEqualTo, "a"))
+
+	fail(t, so(0, ShouldBeGreaterThanOrEqualTo, 1), "Expected '0' to be greater than or equal to '1' (but it wasn't)!")
+	fail(t, so(1, ShouldBeGreaterThanOrEqualTo, 1.1), "Expected '1' to be greater than or equal to '1.1' (but it wasn't)!")
+	fail(t, so(uint(0), ShouldBeGreaterThanOrEqualTo, 1.1), "Expected '0' to be greater than or equal to '1.1' (but it wasn't)!")
+	fail(t, so("a", ShouldBeGreaterThanOrEqualTo, "b"), "Expected 'a' to be greater than or equal to 'b' (but it wasn't)!")
+}
+
+func TestShouldBeLessThan(t *testing.T) {
+	fail(t, so(1, ShouldBeLessThan), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(1, ShouldBeLessThan, 0, 0), "This assertion requires exactly 1 comparison values (you provided 2).")
+
+	pass(t, so(0, ShouldBeLessThan, 1))
+	pass(t, so(1, ShouldBeLessThan, 1.1))
+	pass(t, so(uint(0), ShouldBeLessThan, 1))
+	pass(t, so("a", ShouldBeLessThan, "b"))
+
+	fail(t, so(1, ShouldBeLessThan, 0), "Expected '1' to be less than '0' (but it wasn't)!")
+	fail(t, so(1.1, ShouldBeLessThan, 1), "Expected '1.1' to be less than '1' (but it wasn't)!")
+	fail(t, so(1.1, ShouldBeLessThan, uint(0)), "Expected '1.1' to be less than '0' (but it wasn't)!")
+	fail(t, so("b", ShouldBeLessThan, "a"), "Expected 'b' to be less than 'a' (but it wasn't)!")
+}
+
+func TestShouldBeLessThanOrEqualTo(t *testing.T) {
+	fail(t, so(1, ShouldBeLessThanOrEqualTo), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(1, ShouldBeLessThanOrEqualTo, 0, 0), "This assertion requires exactly 1 comparison values (you provided 2).")
+
+	pass(t, so(1, ShouldBeLessThanOrEqualTo, 1))
+	pass(t, so(1.1, ShouldBeLessThanOrEqualTo, 1.1))
+	pass(t, so(uint(1), ShouldBeLessThanOrEqualTo, 1))
+	pass(t, so("b", ShouldBeLessThanOrEqualTo, "b"))
+
+	pass(t, so(0, ShouldBeLessThanOrEqualTo, 1))
+	pass(t, so(1, ShouldBeLessThanOrEqualTo, 1.1))
+	pass(t, so(uint(0), ShouldBeLessThanOrEqualTo, 1))
+	pass(t, so("a", ShouldBeLessThanOrEqualTo, "b"))
+
+	fail(t, so(1, ShouldBeLessThanOrEqualTo, 0), "Expected '1' to be less than or equal to '0' (but it wasn't)!")
+	fail(t, so(1.1, ShouldBeLessThanOrEqualTo, 1), "Expected '1.1' to be less than or equal to '1' (but it wasn't)!")
+	fail(t, so(1.1, ShouldBeLessThanOrEqualTo, uint(0)), "Expected '1.1' to be less than or equal to '0' (but it wasn't)!")
+	fail(t, so("b", ShouldBeLessThanOrEqualTo, "a"), "Expected 'b' to be less than or equal to 'a' (but it wasn't)!")
+}
+
+func TestShouldBeBetween(t *testing.T) {
+	fail(t, so(1, ShouldBeBetween), "This assertion requires exactly 2 comparison values (you provided 0).")
+	fail(t, so(1, ShouldBeBetween, 1, 2, 3), "This assertion requires exactly 2 comparison values (you provided 3).")
+
+	fail(t, so(4, ShouldBeBetween, 1, 1), "The lower and upper bounds must be different values (they were both '1').")
+
+	fail(t, so(7, ShouldBeBetween, 8, 12), "Expected '7' to be between '8' and '12' (but it wasn't)!")
+	fail(t, so(8, ShouldBeBetween, 8, 12), "Expected '8' to be between '8' and '12' (but it wasn't)!")
+	pass(t, so(9, ShouldBeBetween, 8, 12))
+	pass(t, so(10, ShouldBeBetween, 8, 12))
+	pass(t, so(11, ShouldBeBetween, 8, 12))
+	fail(t, so(12, ShouldBeBetween, 8, 12), "Expected '12' to be between '8' and '12' (but it wasn't)!")
+	fail(t, so(13, ShouldBeBetween, 8, 12), "Expected '13' to be between '8' and '12' (but it wasn't)!")
+
+	pass(t, so(1, ShouldBeBetween, 2, 0))
+	fail(t, so(-1, ShouldBeBetween, 2, 0), "Expected '-1' to be between '0' and '2' (but it wasn't)!")
+}
+
+func TestShouldNotBeBetween(t *testing.T) {
+	fail(t, so(1, ShouldNotBeBetween), "This assertion requires exactly 2 comparison values (you provided 0).")
+	fail(t, so(1, ShouldNotBeBetween, 1, 2, 3), "This assertion requires exactly 2 comparison values (you provided 3).")
+
+	fail(t, so(4, ShouldNotBeBetween, 1, 1), "The lower and upper bounds must be different values (they were both '1').")
+
+	pass(t, so(7, ShouldNotBeBetween, 8, 12))
+	pass(t, so(8, ShouldNotBeBetween, 8, 12))
+	fail(t, so(9, ShouldNotBeBetween, 8, 12), "Expected '9' NOT to be between '8' and '12' (but it was)!")
+	fail(t, so(10, ShouldNotBeBetween, 8, 12), "Expected '10' NOT to be between '8' and '12' (but it was)!")
+	fail(t, so(11, ShouldNotBeBetween, 8, 12), "Expected '11' NOT to be between '8' and '12' (but it was)!")
+	pass(t, so(12, ShouldNotBeBetween, 8, 12))
+	pass(t, so(13, ShouldNotBeBetween, 8, 12))
+
+	pass(t, so(-1, ShouldNotBeBetween, 2, 0))
+	fail(t, so(1, ShouldNotBeBetween, 2, 0), "Expected '1' NOT to be between '0' and '2' (but it was)!")
+}
+
+func TestShouldBeBetweenOrEqual(t *testing.T) {
+	fail(t, so(1, ShouldBeBetweenOrEqual), "This assertion requires exactly 2 comparison values (you provided 0).")
+	fail(t, so(1, ShouldBeBetweenOrEqual, 1, 2, 3), "This assertion requires exactly 2 comparison values (you provided 3).")
+
+	fail(t, so(4, ShouldBeBetweenOrEqual, 1, 1), "The lower and upper bounds must be different values (they were both '1').")
+
+	fail(t, so(7, ShouldBeBetweenOrEqual, 8, 12), "Expected '7' to be between '8' and '12' or equal to one of them (but it wasn't)!")
+	pass(t, so(8, ShouldBeBetweenOrEqual, 8, 12))
+	pass(t, so(9, ShouldBeBetweenOrEqual, 8, 12))
+	pass(t, so(10, ShouldBeBetweenOrEqual, 8, 12))
+	pass(t, so(11, ShouldBeBetweenOrEqual, 8, 12))
+	pass(t, so(12, ShouldBeBetweenOrEqual, 8, 12))
+	fail(t, so(13, ShouldBeBetweenOrEqual, 8, 12), "Expected '13' to be between '8' and '12' or equal to one of them (but it wasn't)!")
+
+	pass(t, so(1, ShouldBeBetweenOrEqual, 2, 0))
+	fail(t, so(-1, ShouldBeBetweenOrEqual, 2, 0), "Expected '-1' to be between '0' and '2' or equal to one of them (but it wasn't)!")
+}
+
+func TestShouldNotBeBetweenOrEqual(t *testing.T) {
+	fail(t, so(1, ShouldNotBeBetweenOrEqual), "This assertion requires exactly 2 comparison values (you provided 0).")
+	fail(t, so(1, ShouldNotBeBetweenOrEqual, 1, 2, 3), "This assertion requires exactly 2 comparison values (you provided 3).")
+
+	fail(t, so(4, ShouldNotBeBetweenOrEqual, 1, 1), "The lower and upper bounds must be different values (they were both '1').")
+
+	pass(t, so(7, ShouldNotBeBetweenOrEqual, 8, 12))
+	fail(t, so(8, ShouldNotBeBetweenOrEqual, 8, 12), "Expected '8' NOT to be between '8' and '12' or equal to one of them (but it was)!")
+	fail(t, so(9, ShouldNotBeBetweenOrEqual, 8, 12), "Expected '9' NOT to be between '8' and '12' or equal to one of them (but it was)!")
+	fail(t, so(10, ShouldNotBeBetweenOrEqual, 8, 12), "Expected '10' NOT to be between '8' and '12' or equal to one of them (but it was)!")
+	fail(t, so(11, ShouldNotBeBetweenOrEqual, 8, 12), "Expected '11' NOT to be between '8' and '12' or equal to one of them (but it was)!")
+	fail(t, so(12, ShouldNotBeBetweenOrEqual, 8, 12), "Expected '12' NOT to be between '8' and '12' or equal to one of them (but it was)!")
+	pass(t, so(13, ShouldNotBeBetweenOrEqual, 8, 12))
+
+	pass(t, so(-1, ShouldNotBeBetweenOrEqual, 2, 0))
+	fail(t, so(1, ShouldNotBeBetweenOrEqual, 2, 0), "Expected '1' NOT to be between '0' and '2' or equal to one of them (but it was)!")
+}

--- a/vendor/github.com/smartystreets/assertions/serializer.go
+++ b/vendor/github.com/smartystreets/assertions/serializer.go
@@ -1,0 +1,69 @@
+package assertions
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/smartystreets/assertions/internal/go-render/render"
+)
+
+type Serializer interface {
+	serialize(expected, actual interface{}, message string) string
+	serializeDetailed(expected, actual interface{}, message string) string
+}
+
+type failureSerializer struct{}
+
+func (self *failureSerializer) serializeDetailed(expected, actual interface{}, message string) string {
+	view := FailureView{
+		Message:  message,
+		Expected: render.Render(expected),
+		Actual:   render.Render(actual),
+	}
+	serialized, err := json.Marshal(view)
+	if err != nil {
+		return message
+	}
+	return string(serialized)
+}
+
+func (self *failureSerializer) serialize(expected, actual interface{}, message string) string {
+	view := FailureView{
+		Message:  message,
+		Expected: fmt.Sprintf("%+v", expected),
+		Actual:   fmt.Sprintf("%+v", actual),
+	}
+	serialized, err := json.Marshal(view)
+	if err != nil {
+		return message
+	}
+	return string(serialized)
+}
+
+func newSerializer() *failureSerializer {
+	return &failureSerializer{}
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+// This struct is also declared in github.com/smartystreets/goconvey/convey/reporting.
+// The json struct tags should be equal in both declarations.
+type FailureView struct {
+	Message  string `json:"Message"`
+	Expected string `json:"Expected"`
+	Actual   string `json:"Actual"`
+}
+
+///////////////////////////////////////////////////////
+
+// noopSerializer just gives back the original message. This is useful when we are using
+// the assertions from a context other than the GoConvey Web UI, that requires the JSON
+// structure provided by the failureSerializer.
+type noopSerializer struct{}
+
+func (self *noopSerializer) serialize(expected, actual interface{}, message string) string {
+	return message
+}
+func (self *noopSerializer) serializeDetailed(expected, actual interface{}, message string) string {
+	return message
+}

--- a/vendor/github.com/smartystreets/assertions/serializer_test.go
+++ b/vendor/github.com/smartystreets/assertions/serializer_test.go
@@ -1,0 +1,36 @@
+package assertions
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestSerializerCreatesSerializedVersionOfAssertionResult(t *testing.T) {
+	thing1 := Thing1{"Hi"}
+	thing2 := Thing2{"Bye"}
+	message := "Super-hip failure message."
+	serializer := newSerializer()
+
+	actualResult := serializer.serialize(thing1, thing2, message)
+
+	expectedResult, _ := json.Marshal(FailureView{
+		Message:  message,
+		Expected: fmt.Sprintf("%+v", thing1),
+		Actual:   fmt.Sprintf("%+v", thing2),
+	})
+
+	if actualResult != string(expectedResult) {
+		t.Errorf("\nExpected: %s\nActual:   %s", string(expectedResult), actualResult)
+	}
+
+	actualResult = serializer.serializeDetailed(thing1, thing2, message)
+	expectedResult, _ = json.Marshal(FailureView{
+		Message:  message,
+		Expected: fmt.Sprintf("%#v", thing1),
+		Actual:   fmt.Sprintf("%#v", thing2),
+	})
+	if actualResult != string(expectedResult) {
+		t.Errorf("\nExpected: %s\nActual:   %s", string(expectedResult), actualResult)
+	}
+}

--- a/vendor/github.com/smartystreets/assertions/strings.go
+++ b/vendor/github.com/smartystreets/assertions/strings.go
@@ -1,0 +1,227 @@
+package assertions
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// ShouldStartWith receives exactly 2 string parameters and ensures that the first starts with the second.
+func ShouldStartWith(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	value, valueIsString := actual.(string)
+	prefix, prefixIsString := expected[0].(string)
+
+	if !valueIsString || !prefixIsString {
+		return fmt.Sprintf(shouldBothBeStrings, reflect.TypeOf(actual), reflect.TypeOf(expected[0]))
+	}
+
+	return shouldStartWith(value, prefix)
+}
+func shouldStartWith(value, prefix string) string {
+	if !strings.HasPrefix(value, prefix) {
+		shortval := value
+		if len(shortval) > len(prefix) {
+			shortval = shortval[:len(prefix)] + "..."
+		}
+		return serializer.serialize(prefix, shortval, fmt.Sprintf(shouldHaveStartedWith, value, prefix))
+	}
+	return success
+}
+
+// ShouldNotStartWith receives exactly 2 string parameters and ensures that the first does not start with the second.
+func ShouldNotStartWith(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	value, valueIsString := actual.(string)
+	prefix, prefixIsString := expected[0].(string)
+
+	if !valueIsString || !prefixIsString {
+		return fmt.Sprintf(shouldBothBeStrings, reflect.TypeOf(actual), reflect.TypeOf(expected[0]))
+	}
+
+	return shouldNotStartWith(value, prefix)
+}
+func shouldNotStartWith(value, prefix string) string {
+	if strings.HasPrefix(value, prefix) {
+		if value == "" {
+			value = "<empty>"
+		}
+		if prefix == "" {
+			prefix = "<empty>"
+		}
+		return fmt.Sprintf(shouldNotHaveStartedWith, value, prefix)
+	}
+	return success
+}
+
+// ShouldEndWith receives exactly 2 string parameters and ensures that the first ends with the second.
+func ShouldEndWith(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	value, valueIsString := actual.(string)
+	suffix, suffixIsString := expected[0].(string)
+
+	if !valueIsString || !suffixIsString {
+		return fmt.Sprintf(shouldBothBeStrings, reflect.TypeOf(actual), reflect.TypeOf(expected[0]))
+	}
+
+	return shouldEndWith(value, suffix)
+}
+func shouldEndWith(value, suffix string) string {
+	if !strings.HasSuffix(value, suffix) {
+		shortval := value
+		if len(shortval) > len(suffix) {
+			shortval = "..." + shortval[len(shortval)-len(suffix):]
+		}
+		return serializer.serialize(suffix, shortval, fmt.Sprintf(shouldHaveEndedWith, value, suffix))
+	}
+	return success
+}
+
+// ShouldEndWith receives exactly 2 string parameters and ensures that the first does not end with the second.
+func ShouldNotEndWith(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	value, valueIsString := actual.(string)
+	suffix, suffixIsString := expected[0].(string)
+
+	if !valueIsString || !suffixIsString {
+		return fmt.Sprintf(shouldBothBeStrings, reflect.TypeOf(actual), reflect.TypeOf(expected[0]))
+	}
+
+	return shouldNotEndWith(value, suffix)
+}
+func shouldNotEndWith(value, suffix string) string {
+	if strings.HasSuffix(value, suffix) {
+		if value == "" {
+			value = "<empty>"
+		}
+		if suffix == "" {
+			suffix = "<empty>"
+		}
+		return fmt.Sprintf(shouldNotHaveEndedWith, value, suffix)
+	}
+	return success
+}
+
+// ShouldContainSubstring receives exactly 2 string parameters and ensures that the first contains the second as a substring.
+func ShouldContainSubstring(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	long, longOk := actual.(string)
+	short, shortOk := expected[0].(string)
+
+	if !longOk || !shortOk {
+		return fmt.Sprintf(shouldBothBeStrings, reflect.TypeOf(actual), reflect.TypeOf(expected[0]))
+	}
+
+	if !strings.Contains(long, short) {
+		return serializer.serialize(expected[0], actual, fmt.Sprintf(shouldHaveContainedSubstring, long, short))
+	}
+	return success
+}
+
+// ShouldNotContainSubstring receives exactly 2 string parameters and ensures that the first does NOT contain the second as a substring.
+func ShouldNotContainSubstring(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	long, longOk := actual.(string)
+	short, shortOk := expected[0].(string)
+
+	if !longOk || !shortOk {
+		return fmt.Sprintf(shouldBothBeStrings, reflect.TypeOf(actual), reflect.TypeOf(expected[0]))
+	}
+
+	if strings.Contains(long, short) {
+		return fmt.Sprintf(shouldNotHaveContainedSubstring, long, short)
+	}
+	return success
+}
+
+// ShouldBeBlank receives exactly 1 string parameter and ensures that it is equal to "".
+func ShouldBeBlank(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	}
+	value, ok := actual.(string)
+	if !ok {
+		return fmt.Sprintf(shouldBeString, reflect.TypeOf(actual))
+	}
+	if value != "" {
+		return serializer.serialize("", value, fmt.Sprintf(shouldHaveBeenBlank, value))
+	}
+	return success
+}
+
+// ShouldNotBeBlank receives exactly 1 string parameter and ensures that it is equal to "".
+func ShouldNotBeBlank(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	}
+	value, ok := actual.(string)
+	if !ok {
+		return fmt.Sprintf(shouldBeString, reflect.TypeOf(actual))
+	}
+	if value == "" {
+		return shouldNotHaveBeenBlank
+	}
+	return success
+}
+
+// ShouldEqualWithout receives exactly 3 string parameters and ensures that the first is equal to the second
+// after removing all instances of the third from the first using strings.Replace(first, third, "", -1).
+func ShouldEqualWithout(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	actualString, ok1 := actual.(string)
+	expectedString, ok2 := expected[0].(string)
+	replace, ok3 := expected[1].(string)
+
+	if !ok1 || !ok2 || !ok3 {
+		return fmt.Sprintf(shouldAllBeStrings, []reflect.Type{
+			reflect.TypeOf(actual),
+			reflect.TypeOf(expected[0]),
+			reflect.TypeOf(expected[1]),
+		})
+	}
+
+	replaced := strings.Replace(actualString, replace, "", -1)
+	if replaced == expectedString {
+		return ""
+	}
+
+	return fmt.Sprintf("Expected '%s' to equal '%s' but without any '%s' (but it didn't).", actualString, expectedString, replace)
+}
+
+// ShouldEqualTrimSpace receives exactly 2 string parameters and ensures that the first is equal to the second
+// after removing all leading and trailing whitespace using strings.TrimSpace(first).
+func ShouldEqualTrimSpace(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	actualString, valueIsString := actual.(string)
+	_, value2IsString := expected[0].(string)
+
+	if !valueIsString || !value2IsString {
+		return fmt.Sprintf(shouldBothBeStrings, reflect.TypeOf(actual), reflect.TypeOf(expected[0]))
+	}
+
+	actualString = strings.TrimSpace(actualString)
+	return ShouldEqual(actualString, expected[0])
+}

--- a/vendor/github.com/smartystreets/assertions/strings_test.go
+++ b/vendor/github.com/smartystreets/assertions/strings_test.go
@@ -1,0 +1,118 @@
+package assertions
+
+import "testing"
+
+func TestShouldStartWith(t *testing.T) {
+	serializer = newFakeSerializer()
+
+	fail(t, so("", ShouldStartWith), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so("", ShouldStartWith, "asdf", "asdf"), "This assertion requires exactly 1 comparison values (you provided 2).")
+
+	pass(t, so("", ShouldStartWith, ""))
+	fail(t, so("", ShouldStartWith, "x"), "x||Expected '' to start with 'x' (but it didn't)!")
+	pass(t, so("abc", ShouldStartWith, "abc"))
+	fail(t, so("abc", ShouldStartWith, "abcd"), "abcd|abc|Expected 'abc' to start with 'abcd' (but it didn't)!")
+
+	pass(t, so("superman", ShouldStartWith, "super"))
+	fail(t, so("superman", ShouldStartWith, "bat"), "bat|sup...|Expected 'superman' to start with 'bat' (but it didn't)!")
+	fail(t, so("superman", ShouldStartWith, "man"), "man|sup...|Expected 'superman' to start with 'man' (but it didn't)!")
+
+	fail(t, so(1, ShouldStartWith, 2), "Both arguments to this assertion must be strings (you provided int and int).")
+}
+
+func TestShouldNotStartWith(t *testing.T) {
+	fail(t, so("", ShouldNotStartWith), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so("", ShouldNotStartWith, "asdf", "asdf"), "This assertion requires exactly 1 comparison values (you provided 2).")
+
+	fail(t, so("", ShouldNotStartWith, ""), "Expected '<empty>' NOT to start with '<empty>' (but it did)!")
+	fail(t, so("superman", ShouldNotStartWith, "super"), "Expected 'superman' NOT to start with 'super' (but it did)!")
+	pass(t, so("superman", ShouldNotStartWith, "bat"))
+	pass(t, so("superman", ShouldNotStartWith, "man"))
+
+	fail(t, so(1, ShouldNotStartWith, 2), "Both arguments to this assertion must be strings (you provided int and int).")
+}
+
+func TestShouldEndWith(t *testing.T) {
+	serializer = newFakeSerializer()
+
+	fail(t, so("", ShouldEndWith), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so("", ShouldEndWith, "", ""), "This assertion requires exactly 1 comparison values (you provided 2).")
+
+	pass(t, so("", ShouldEndWith, ""))
+	fail(t, so("", ShouldEndWith, "z"), "z||Expected '' to end with 'z' (but it didn't)!")
+	pass(t, so("xyz", ShouldEndWith, "xyz"))
+	fail(t, so("xyz", ShouldEndWith, "wxyz"), "wxyz|xyz|Expected 'xyz' to end with 'wxyz' (but it didn't)!")
+
+	pass(t, so("superman", ShouldEndWith, "man"))
+	fail(t, so("superman", ShouldEndWith, "super"), "super|...erman|Expected 'superman' to end with 'super' (but it didn't)!")
+	fail(t, so("superman", ShouldEndWith, "blah"), "blah|...rman|Expected 'superman' to end with 'blah' (but it didn't)!")
+
+	fail(t, so(1, ShouldEndWith, 2), "Both arguments to this assertion must be strings (you provided int and int).")
+}
+
+func TestShouldNotEndWith(t *testing.T) {
+	fail(t, so("", ShouldNotEndWith), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so("", ShouldNotEndWith, "", ""), "This assertion requires exactly 1 comparison values (you provided 2).")
+
+	fail(t, so("", ShouldNotEndWith, ""), "Expected '<empty>' NOT to end with '<empty>' (but it did)!")
+	fail(t, so("superman", ShouldNotEndWith, "man"), "Expected 'superman' NOT to end with 'man' (but it did)!")
+	pass(t, so("superman", ShouldNotEndWith, "super"))
+
+	fail(t, so(1, ShouldNotEndWith, 2), "Both arguments to this assertion must be strings (you provided int and int).")
+}
+
+func TestShouldContainSubstring(t *testing.T) {
+	serializer = newFakeSerializer()
+
+	fail(t, so("asdf", ShouldContainSubstring), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so("asdf", ShouldContainSubstring, 1, 2, 3), "This assertion requires exactly 1 comparison values (you provided 3).")
+
+	fail(t, so(123, ShouldContainSubstring, 23), "Both arguments to this assertion must be strings (you provided int and int).")
+
+	pass(t, so("asdf", ShouldContainSubstring, "sd"))
+	fail(t, so("qwer", ShouldContainSubstring, "sd"), "sd|qwer|Expected 'qwer' to contain substring 'sd' (but it didn't)!")
+}
+
+func TestShouldNotContainSubstring(t *testing.T) {
+	fail(t, so("asdf", ShouldNotContainSubstring), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so("asdf", ShouldNotContainSubstring, 1, 2, 3), "This assertion requires exactly 1 comparison values (you provided 3).")
+
+	fail(t, so(123, ShouldNotContainSubstring, 23), "Both arguments to this assertion must be strings (you provided int and int).")
+
+	pass(t, so("qwer", ShouldNotContainSubstring, "sd"))
+	fail(t, so("asdf", ShouldNotContainSubstring, "sd"), "Expected 'asdf' NOT to contain substring 'sd' (but it did)!")
+}
+
+func TestShouldBeBlank(t *testing.T) {
+	serializer = newFakeSerializer()
+
+	fail(t, so("", ShouldBeBlank, "adsf"), "This assertion requires exactly 0 comparison values (you provided 1).")
+	fail(t, so(1, ShouldBeBlank), "The argument to this assertion must be a string (you provided int).")
+
+	fail(t, so("asdf", ShouldBeBlank), "|asdf|Expected 'asdf' to be blank (but it wasn't)!")
+	pass(t, so("", ShouldBeBlank))
+}
+
+func TestShouldNotBeBlank(t *testing.T) {
+	fail(t, so("", ShouldNotBeBlank, "adsf"), "This assertion requires exactly 0 comparison values (you provided 1).")
+	fail(t, so(1, ShouldNotBeBlank), "The argument to this assertion must be a string (you provided int).")
+
+	fail(t, so("", ShouldNotBeBlank), "Expected value to NOT be blank (but it was)!")
+	pass(t, so("asdf", ShouldNotBeBlank))
+}
+
+func TestShouldEqualWithout(t *testing.T) {
+	fail(t, so("", ShouldEqualWithout, ""), "This assertion requires exactly 2 comparison values (you provided 1).")
+	fail(t, so(1, ShouldEqualWithout, 2, 3), "All arguments to this assertion must be strings (you provided: [int int int]).")
+
+	fail(t, so("asdf", ShouldEqualWithout, "qwer", "q"), "Expected 'asdf' to equal 'qwer' but without any 'q' (but it didn't).")
+	pass(t, so("asdf", ShouldEqualWithout, "df", "as"))
+}
+
+func TestShouldEqualTrimSpace(t *testing.T) {
+	fail(t, so(" asdf ", ShouldEqualTrimSpace), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(1, ShouldEqualTrimSpace, 2), "Both arguments to this assertion must be strings (you provided int and int).")
+
+	fail(t, so("asdf", ShouldEqualTrimSpace, "qwer"), "qwer|asdf|Expected: 'qwer' Actual: 'asdf' (Should be equal)")
+	pass(t, so(" asdf\t\n", ShouldEqualTrimSpace, "asdf"))
+}

--- a/vendor/github.com/smartystreets/assertions/time.go
+++ b/vendor/github.com/smartystreets/assertions/time.go
@@ -1,0 +1,202 @@
+package assertions
+
+import (
+	"fmt"
+	"time"
+)
+
+// ShouldHappenBefore receives exactly 2 time.Time arguments and asserts that the first happens before the second.
+func ShouldHappenBefore(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+	actualTime, firstOk := actual.(time.Time)
+	expectedTime, secondOk := expected[0].(time.Time)
+
+	if !firstOk || !secondOk {
+		return shouldUseTimes
+	}
+
+	if !actualTime.Before(expectedTime) {
+		return fmt.Sprintf(shouldHaveHappenedBefore, actualTime, expectedTime, actualTime.Sub(expectedTime))
+	}
+
+	return success
+}
+
+// ShouldHappenOnOrBefore receives exactly 2 time.Time arguments and asserts that the first happens on or before the second.
+func ShouldHappenOnOrBefore(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+	actualTime, firstOk := actual.(time.Time)
+	expectedTime, secondOk := expected[0].(time.Time)
+
+	if !firstOk || !secondOk {
+		return shouldUseTimes
+	}
+
+	if actualTime.Equal(expectedTime) {
+		return success
+	}
+	return ShouldHappenBefore(actualTime, expectedTime)
+}
+
+// ShouldHappenAfter receives exactly 2 time.Time arguments and asserts that the first happens after the second.
+func ShouldHappenAfter(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+	actualTime, firstOk := actual.(time.Time)
+	expectedTime, secondOk := expected[0].(time.Time)
+
+	if !firstOk || !secondOk {
+		return shouldUseTimes
+	}
+	if !actualTime.After(expectedTime) {
+		return fmt.Sprintf(shouldHaveHappenedAfter, actualTime, expectedTime, expectedTime.Sub(actualTime))
+	}
+	return success
+}
+
+// ShouldHappenOnOrAfter receives exactly 2 time.Time arguments and asserts that the first happens on or after the second.
+func ShouldHappenOnOrAfter(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+	actualTime, firstOk := actual.(time.Time)
+	expectedTime, secondOk := expected[0].(time.Time)
+
+	if !firstOk || !secondOk {
+		return shouldUseTimes
+	}
+	if actualTime.Equal(expectedTime) {
+		return success
+	}
+	return ShouldHappenAfter(actualTime, expectedTime)
+}
+
+// ShouldHappenBetween receives exactly 3 time.Time arguments and asserts that the first happens between (not on) the second and third.
+func ShouldHappenBetween(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	actualTime, firstOk := actual.(time.Time)
+	min, secondOk := expected[0].(time.Time)
+	max, thirdOk := expected[1].(time.Time)
+
+	if !firstOk || !secondOk || !thirdOk {
+		return shouldUseTimes
+	}
+
+	if !actualTime.After(min) {
+		return fmt.Sprintf(shouldHaveHappenedBetween, actualTime, min, max, min.Sub(actualTime))
+	}
+	if !actualTime.Before(max) {
+		return fmt.Sprintf(shouldHaveHappenedBetween, actualTime, min, max, actualTime.Sub(max))
+	}
+	return success
+}
+
+// ShouldHappenOnOrBetween receives exactly 3 time.Time arguments and asserts that the first happens between or on the second and third.
+func ShouldHappenOnOrBetween(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	actualTime, firstOk := actual.(time.Time)
+	min, secondOk := expected[0].(time.Time)
+	max, thirdOk := expected[1].(time.Time)
+
+	if !firstOk || !secondOk || !thirdOk {
+		return shouldUseTimes
+	}
+	if actualTime.Equal(min) || actualTime.Equal(max) {
+		return success
+	}
+	return ShouldHappenBetween(actualTime, min, max)
+}
+
+// ShouldNotHappenOnOrBetween receives exactly 3 time.Time arguments and asserts that the first
+// does NOT happen between or on the second or third.
+func ShouldNotHappenOnOrBetween(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	actualTime, firstOk := actual.(time.Time)
+	min, secondOk := expected[0].(time.Time)
+	max, thirdOk := expected[1].(time.Time)
+
+	if !firstOk || !secondOk || !thirdOk {
+		return shouldUseTimes
+	}
+	if actualTime.Equal(min) || actualTime.Equal(max) {
+		return fmt.Sprintf(shouldNotHaveHappenedOnOrBetween, actualTime, min, max)
+	}
+	if actualTime.After(min) && actualTime.Before(max) {
+		return fmt.Sprintf(shouldNotHaveHappenedOnOrBetween, actualTime, min, max)
+	}
+	return success
+}
+
+// ShouldHappenWithin receives a time.Time, a time.Duration, and a time.Time (3 arguments)
+// and asserts that the first time.Time happens within or on the duration specified relative to
+// the other time.Time.
+func ShouldHappenWithin(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	actualTime, firstOk := actual.(time.Time)
+	tolerance, secondOk := expected[0].(time.Duration)
+	threshold, thirdOk := expected[1].(time.Time)
+
+	if !firstOk || !secondOk || !thirdOk {
+		return shouldUseDurationAndTime
+	}
+
+	min := threshold.Add(-tolerance)
+	max := threshold.Add(tolerance)
+	return ShouldHappenOnOrBetween(actualTime, min, max)
+}
+
+// ShouldNotHappenWithin receives a time.Time, a time.Duration, and a time.Time (3 arguments)
+// and asserts that the first time.Time does NOT happen within or on the duration specified relative to
+// the other time.Time.
+func ShouldNotHappenWithin(actual interface{}, expected ...interface{}) string {
+	if fail := need(2, expected); fail != success {
+		return fail
+	}
+	actualTime, firstOk := actual.(time.Time)
+	tolerance, secondOk := expected[0].(time.Duration)
+	threshold, thirdOk := expected[1].(time.Time)
+
+	if !firstOk || !secondOk || !thirdOk {
+		return shouldUseDurationAndTime
+	}
+
+	min := threshold.Add(-tolerance)
+	max := threshold.Add(tolerance)
+	return ShouldNotHappenOnOrBetween(actualTime, min, max)
+}
+
+// ShouldBeChronological receives a []time.Time slice and asserts that the are
+// in chronological order starting with the first time.Time as the earliest.
+func ShouldBeChronological(actual interface{}, expected ...interface{}) string {
+	if fail := need(0, expected); fail != success {
+		return fail
+	}
+
+	times, ok := actual.([]time.Time)
+	if !ok {
+		return shouldUseTimeSlice
+	}
+
+	var previous time.Time
+	for i, current := range times {
+		if i > 0 && current.Before(previous) {
+			return fmt.Sprintf(shouldHaveBeenChronological,
+				i, i-1, previous.String(), i, current.String())
+		}
+		previous = current
+	}
+	return ""
+}

--- a/vendor/github.com/smartystreets/assertions/time_test.go
+++ b/vendor/github.com/smartystreets/assertions/time_test.go
@@ -1,0 +1,159 @@
+package assertions
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestShouldHappenBefore(t *testing.T) {
+	fail(t, so(0, ShouldHappenBefore), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(0, ShouldHappenBefore, 1, 2, 3), "This assertion requires exactly 1 comparison values (you provided 3).")
+
+	fail(t, so(0, ShouldHappenBefore, 1), shouldUseTimes)
+	fail(t, so(0, ShouldHappenBefore, time.Now()), shouldUseTimes)
+	fail(t, so(time.Now(), ShouldHappenBefore, 0), shouldUseTimes)
+
+	fail(t, so(january3, ShouldHappenBefore, january1), fmt.Sprintf("Expected '%s' to happen before '%s' (it happened '48h0m0s' after)!", pretty(january3), pretty(january1)))
+	fail(t, so(january3, ShouldHappenBefore, january3), fmt.Sprintf("Expected '%s' to happen before '%s' (it happened '0s' after)!", pretty(january3), pretty(january3)))
+	pass(t, so(january1, ShouldHappenBefore, january3))
+}
+
+func TestShouldHappenOnOrBefore(t *testing.T) {
+	fail(t, so(0, ShouldHappenOnOrBefore), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(0, ShouldHappenOnOrBefore, 1, 2, 3), "This assertion requires exactly 1 comparison values (you provided 3).")
+
+	fail(t, so(0, ShouldHappenOnOrBefore, 1), shouldUseTimes)
+	fail(t, so(0, ShouldHappenOnOrBefore, time.Now()), shouldUseTimes)
+	fail(t, so(time.Now(), ShouldHappenOnOrBefore, 0), shouldUseTimes)
+
+	fail(t, so(january3, ShouldHappenOnOrBefore, january1), fmt.Sprintf("Expected '%s' to happen before '%s' (it happened '48h0m0s' after)!", pretty(january3), pretty(january1)))
+	pass(t, so(january3, ShouldHappenOnOrBefore, january3))
+	pass(t, so(january1, ShouldHappenOnOrBefore, january3))
+}
+
+func TestShouldHappenAfter(t *testing.T) {
+	fail(t, so(0, ShouldHappenAfter), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(0, ShouldHappenAfter, 1, 2, 3), "This assertion requires exactly 1 comparison values (you provided 3).")
+
+	fail(t, so(0, ShouldHappenAfter, 1), shouldUseTimes)
+	fail(t, so(0, ShouldHappenAfter, time.Now()), shouldUseTimes)
+	fail(t, so(time.Now(), ShouldHappenAfter, 0), shouldUseTimes)
+
+	fail(t, so(january1, ShouldHappenAfter, january2), fmt.Sprintf("Expected '%s' to happen after '%s' (it happened '24h0m0s' before)!", pretty(january1), pretty(january2)))
+	fail(t, so(january1, ShouldHappenAfter, january1), fmt.Sprintf("Expected '%s' to happen after '%s' (it happened '0s' before)!", pretty(january1), pretty(january1)))
+	pass(t, so(january3, ShouldHappenAfter, january1))
+}
+
+func TestShouldHappenOnOrAfter(t *testing.T) {
+	fail(t, so(0, ShouldHappenOnOrAfter), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(0, ShouldHappenOnOrAfter, 1, 2, 3), "This assertion requires exactly 1 comparison values (you provided 3).")
+
+	fail(t, so(0, ShouldHappenOnOrAfter, 1), shouldUseTimes)
+	fail(t, so(0, ShouldHappenOnOrAfter, time.Now()), shouldUseTimes)
+	fail(t, so(time.Now(), ShouldHappenOnOrAfter, 0), shouldUseTimes)
+
+	fail(t, so(january1, ShouldHappenOnOrAfter, january2), fmt.Sprintf("Expected '%s' to happen after '%s' (it happened '24h0m0s' before)!", pretty(january1), pretty(january2)))
+	pass(t, so(january1, ShouldHappenOnOrAfter, january1))
+	pass(t, so(january3, ShouldHappenOnOrAfter, january1))
+}
+
+func TestShouldHappenBetween(t *testing.T) {
+	fail(t, so(0, ShouldHappenBetween), "This assertion requires exactly 2 comparison values (you provided 0).")
+	fail(t, so(0, ShouldHappenBetween, 1, 2, 3), "This assertion requires exactly 2 comparison values (you provided 3).")
+
+	fail(t, so(0, ShouldHappenBetween, 1, 2), shouldUseTimes)
+	fail(t, so(0, ShouldHappenBetween, time.Now(), time.Now()), shouldUseTimes)
+	fail(t, so(time.Now(), ShouldHappenBetween, 0, time.Now()), shouldUseTimes)
+	fail(t, so(time.Now(), ShouldHappenBetween, time.Now(), 9), shouldUseTimes)
+
+	fail(t, so(january1, ShouldHappenBetween, january2, january4), fmt.Sprintf("Expected '%s' to happen between '%s' and '%s' (it happened '24h0m0s' outside threshold)!", pretty(january1), pretty(january2), pretty(january4)))
+	fail(t, so(january2, ShouldHappenBetween, january2, january4), fmt.Sprintf("Expected '%s' to happen between '%s' and '%s' (it happened '0s' outside threshold)!", pretty(january2), pretty(january2), pretty(january4)))
+	pass(t, so(january3, ShouldHappenBetween, january2, january4))
+	fail(t, so(january4, ShouldHappenBetween, january2, january4), fmt.Sprintf("Expected '%s' to happen between '%s' and '%s' (it happened '0s' outside threshold)!", pretty(january4), pretty(january2), pretty(january4)))
+	fail(t, so(january5, ShouldHappenBetween, january2, january4), fmt.Sprintf("Expected '%s' to happen between '%s' and '%s' (it happened '24h0m0s' outside threshold)!", pretty(january5), pretty(january2), pretty(january4)))
+}
+
+func TestShouldHappenOnOrBetween(t *testing.T) {
+	fail(t, so(0, ShouldHappenOnOrBetween), "This assertion requires exactly 2 comparison values (you provided 0).")
+	fail(t, so(0, ShouldHappenOnOrBetween, 1, 2, 3), "This assertion requires exactly 2 comparison values (you provided 3).")
+
+	fail(t, so(0, ShouldHappenOnOrBetween, 1, time.Now()), shouldUseTimes)
+	fail(t, so(0, ShouldHappenOnOrBetween, time.Now(), 1), shouldUseTimes)
+	fail(t, so(time.Now(), ShouldHappenOnOrBetween, 0, 1), shouldUseTimes)
+
+	fail(t, so(january1, ShouldHappenOnOrBetween, january2, january4), fmt.Sprintf("Expected '%s' to happen between '%s' and '%s' (it happened '24h0m0s' outside threshold)!", pretty(january1), pretty(january2), pretty(january4)))
+	pass(t, so(january2, ShouldHappenOnOrBetween, january2, january4))
+	pass(t, so(january3, ShouldHappenOnOrBetween, january2, january4))
+	pass(t, so(january4, ShouldHappenOnOrBetween, january2, january4))
+	fail(t, so(january5, ShouldHappenOnOrBetween, january2, january4), fmt.Sprintf("Expected '%s' to happen between '%s' and '%s' (it happened '24h0m0s' outside threshold)!", pretty(january5), pretty(january2), pretty(january4)))
+}
+
+func TestShouldNotHappenOnOrBetween(t *testing.T) {
+	fail(t, so(0, ShouldNotHappenOnOrBetween), "This assertion requires exactly 2 comparison values (you provided 0).")
+	fail(t, so(0, ShouldNotHappenOnOrBetween, 1, 2, 3), "This assertion requires exactly 2 comparison values (you provided 3).")
+
+	fail(t, so(0, ShouldNotHappenOnOrBetween, 1, time.Now()), shouldUseTimes)
+	fail(t, so(0, ShouldNotHappenOnOrBetween, time.Now(), 1), shouldUseTimes)
+	fail(t, so(time.Now(), ShouldNotHappenOnOrBetween, 0, 1), shouldUseTimes)
+
+	pass(t, so(january1, ShouldNotHappenOnOrBetween, january2, january4))
+	fail(t, so(january2, ShouldNotHappenOnOrBetween, january2, january4), fmt.Sprintf("Expected '%s' to NOT happen on or between '%s' and '%s' (but it did)!", pretty(january2), pretty(january2), pretty(january4)))
+	fail(t, so(january3, ShouldNotHappenOnOrBetween, january2, january4), fmt.Sprintf("Expected '%s' to NOT happen on or between '%s' and '%s' (but it did)!", pretty(january3), pretty(january2), pretty(january4)))
+	fail(t, so(january4, ShouldNotHappenOnOrBetween, january2, january4), fmt.Sprintf("Expected '%s' to NOT happen on or between '%s' and '%s' (but it did)!", pretty(january4), pretty(january2), pretty(january4)))
+	pass(t, so(january5, ShouldNotHappenOnOrBetween, january2, january4))
+}
+
+func TestShouldHappenWithin(t *testing.T) {
+	fail(t, so(0, ShouldHappenWithin), "This assertion requires exactly 2 comparison values (you provided 0).")
+	fail(t, so(0, ShouldHappenWithin, 1, 2, 3), "This assertion requires exactly 2 comparison values (you provided 3).")
+
+	fail(t, so(0, ShouldHappenWithin, 1, 2), shouldUseDurationAndTime)
+	fail(t, so(0, ShouldHappenWithin, oneDay, time.Now()), shouldUseDurationAndTime)
+	fail(t, so(time.Now(), ShouldHappenWithin, 0, time.Now()), shouldUseDurationAndTime)
+
+	fail(t, so(january1, ShouldHappenWithin, oneDay, january3), fmt.Sprintf("Expected '%s' to happen between '%s' and '%s' (it happened '24h0m0s' outside threshold)!", pretty(january1), pretty(january2), pretty(january4)))
+	pass(t, so(january2, ShouldHappenWithin, oneDay, january3))
+	pass(t, so(january3, ShouldHappenWithin, oneDay, january3))
+	pass(t, so(january4, ShouldHappenWithin, oneDay, january3))
+	fail(t, so(january5, ShouldHappenWithin, oneDay, january3), fmt.Sprintf("Expected '%s' to happen between '%s' and '%s' (it happened '24h0m0s' outside threshold)!", pretty(january5), pretty(january2), pretty(january4)))
+}
+
+func TestShouldNotHappenWithin(t *testing.T) {
+	fail(t, so(0, ShouldNotHappenWithin), "This assertion requires exactly 2 comparison values (you provided 0).")
+	fail(t, so(0, ShouldNotHappenWithin, 1, 2, 3), "This assertion requires exactly 2 comparison values (you provided 3).")
+
+	fail(t, so(0, ShouldNotHappenWithin, 1, 2), shouldUseDurationAndTime)
+	fail(t, so(0, ShouldNotHappenWithin, oneDay, time.Now()), shouldUseDurationAndTime)
+	fail(t, so(time.Now(), ShouldNotHappenWithin, 0, time.Now()), shouldUseDurationAndTime)
+
+	pass(t, so(january1, ShouldNotHappenWithin, oneDay, january3))
+	fail(t, so(january2, ShouldNotHappenWithin, oneDay, january3), fmt.Sprintf("Expected '%s' to NOT happen on or between '%s' and '%s' (but it did)!", pretty(january2), pretty(january2), pretty(january4)))
+	fail(t, so(january3, ShouldNotHappenWithin, oneDay, january3), fmt.Sprintf("Expected '%s' to NOT happen on or between '%s' and '%s' (but it did)!", pretty(january3), pretty(january2), pretty(january4)))
+	fail(t, so(january4, ShouldNotHappenWithin, oneDay, january3), fmt.Sprintf("Expected '%s' to NOT happen on or between '%s' and '%s' (but it did)!", pretty(january4), pretty(january2), pretty(january4)))
+	pass(t, so(january5, ShouldNotHappenWithin, oneDay, january3))
+}
+
+func TestShouldBeChronological(t *testing.T) {
+	fail(t, so(0, ShouldBeChronological, 1, 2, 3), "This assertion requires exactly 0 comparison values (you provided 3).")
+	fail(t, so(0, ShouldBeChronological), shouldUseTimeSlice)
+	fail(t, so([]time.Time{january5, january1}, ShouldBeChronological),
+		"The 'Time' at index [1] should have happened after the previous one (but it didn't!):\n  [0]: 2013-01-05 00:00:00 +0000 UTC\n  [1]: 2013-01-01 00:00:00 +0000 UTC (see, it happened before!)")
+
+	pass(t, so([]time.Time{january1, january2, january3, january4, january5}, ShouldBeChronological))
+}
+
+const layout = "2006-01-02 15:04"
+
+var january1, _ = time.Parse(layout, "2013-01-01 00:00")
+var january2, _ = time.Parse(layout, "2013-01-02 00:00")
+var january3, _ = time.Parse(layout, "2013-01-03 00:00")
+var january4, _ = time.Parse(layout, "2013-01-04 00:00")
+var january5, _ = time.Parse(layout, "2013-01-05 00:00")
+
+var oneDay, _ = time.ParseDuration("24h0m0s")
+var twoDays, _ = time.ParseDuration("48h0m0s")
+
+func pretty(t time.Time) string {
+	return fmt.Sprintf("%v", t)
+}

--- a/vendor/github.com/smartystreets/assertions/type.go
+++ b/vendor/github.com/smartystreets/assertions/type.go
@@ -1,0 +1,112 @@
+package assertions
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// ShouldHaveSameTypeAs receives exactly two parameters and compares their underlying types for equality.
+func ShouldHaveSameTypeAs(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	first := reflect.TypeOf(actual)
+	second := reflect.TypeOf(expected[0])
+
+	if equal := ShouldEqual(first, second); equal != success {
+		return serializer.serialize(second, first, fmt.Sprintf(shouldHaveBeenA, actual, second, first))
+	}
+	return success
+}
+
+// ShouldNotHaveSameTypeAs receives exactly two parameters and compares their underlying types for inequality.
+func ShouldNotHaveSameTypeAs(actual interface{}, expected ...interface{}) string {
+	if fail := need(1, expected); fail != success {
+		return fail
+	}
+
+	first := reflect.TypeOf(actual)
+	second := reflect.TypeOf(expected[0])
+
+	if equal := ShouldEqual(first, second); equal == success {
+		return fmt.Sprintf(shouldNotHaveBeenA, actual, second)
+	}
+	return success
+}
+
+// ShouldImplement receives exactly two parameters and ensures
+// that the first implements the interface type of the second.
+func ShouldImplement(actual interface{}, expectedList ...interface{}) string {
+	if fail := need(1, expectedList); fail != success {
+		return fail
+	}
+
+	expected := expectedList[0]
+	if fail := ShouldBeNil(expected); fail != success {
+		return shouldCompareWithInterfacePointer
+	}
+
+	if fail := ShouldNotBeNil(actual); fail != success {
+		return shouldNotBeNilActual
+	}
+
+	var actualType reflect.Type
+	if reflect.TypeOf(actual).Kind() != reflect.Ptr {
+		actualType = reflect.PtrTo(reflect.TypeOf(actual))
+	} else {
+		actualType = reflect.TypeOf(actual)
+	}
+
+	expectedType := reflect.TypeOf(expected)
+	if fail := ShouldNotBeNil(expectedType); fail != success {
+		return shouldCompareWithInterfacePointer
+	}
+
+	expectedInterface := expectedType.Elem()
+
+	if actualType == nil {
+		return fmt.Sprintf(shouldHaveImplemented, expectedInterface, actual)
+	}
+
+	if !actualType.Implements(expectedInterface) {
+		return fmt.Sprintf(shouldHaveImplemented, expectedInterface, actualType)
+	}
+	return success
+}
+
+// ShouldNotImplement receives exactly two parameters and ensures
+// that the first does NOT implement the interface type of the second.
+func ShouldNotImplement(actual interface{}, expectedList ...interface{}) string {
+	if fail := need(1, expectedList); fail != success {
+		return fail
+	}
+
+	expected := expectedList[0]
+	if fail := ShouldBeNil(expected); fail != success {
+		return shouldCompareWithInterfacePointer
+	}
+
+	if fail := ShouldNotBeNil(actual); fail != success {
+		return shouldNotBeNilActual
+	}
+
+	var actualType reflect.Type
+	if reflect.TypeOf(actual).Kind() != reflect.Ptr {
+		actualType = reflect.PtrTo(reflect.TypeOf(actual))
+	} else {
+		actualType = reflect.TypeOf(actual)
+	}
+
+	expectedType := reflect.TypeOf(expected)
+	if fail := ShouldNotBeNil(expectedType); fail != success {
+		return shouldCompareWithInterfacePointer
+	}
+
+	expectedInterface := expectedType.Elem()
+
+	if actualType.Implements(expectedInterface) {
+		return fmt.Sprintf(shouldNotHaveImplemented, actualType, expectedInterface)
+	}
+	return success
+}

--- a/vendor/github.com/smartystreets/assertions/type_test.go
+++ b/vendor/github.com/smartystreets/assertions/type_test.go
@@ -1,0 +1,76 @@
+package assertions
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestShouldHaveSameTypeAs(t *testing.T) {
+	serializer = newFakeSerializer()
+
+	fail(t, so(1, ShouldHaveSameTypeAs), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(1, ShouldHaveSameTypeAs, 1, 2, 3), "This assertion requires exactly 1 comparison values (you provided 3).")
+
+	fail(t, so(nil, ShouldHaveSameTypeAs, 0), "int|<nil>|Expected '<nil>' to be: 'int' (but was: '<nil>')!")
+	fail(t, so(1, ShouldHaveSameTypeAs, "asdf"), "string|int|Expected '1' to be: 'string' (but was: 'int')!")
+
+	pass(t, so(1, ShouldHaveSameTypeAs, 0))
+	pass(t, so(nil, ShouldHaveSameTypeAs, nil))
+}
+
+func TestShouldNotHaveSameTypeAs(t *testing.T) {
+	fail(t, so(1, ShouldNotHaveSameTypeAs), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(1, ShouldNotHaveSameTypeAs, 1, 2, 3), "This assertion requires exactly 1 comparison values (you provided 3).")
+
+	fail(t, so(1, ShouldNotHaveSameTypeAs, 0), "Expected '1' to NOT be: 'int' (but it was)!")
+	fail(t, so(nil, ShouldNotHaveSameTypeAs, nil), "Expected '<nil>' to NOT be: '<nil>' (but it was)!")
+
+	pass(t, so(nil, ShouldNotHaveSameTypeAs, 0))
+	pass(t, so(1, ShouldNotHaveSameTypeAs, "asdf"))
+}
+
+func TestShouldImplement(t *testing.T) {
+	var ioReader *io.Reader = nil
+	var response http.Response = http.Response{}
+	var responsePtr *http.Response = new(http.Response)
+	var reader = bytes.NewBufferString("")
+
+	fail(t, so(reader, ShouldImplement), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(reader, ShouldImplement, ioReader, ioReader), "This assertion requires exactly 1 comparison values (you provided 2).")
+	fail(t, so(reader, ShouldImplement, ioReader, ioReader, ioReader), "This assertion requires exactly 1 comparison values (you provided 3).")
+
+	fail(t, so(reader, ShouldImplement, "foo"), shouldCompareWithInterfacePointer)
+	fail(t, so(reader, ShouldImplement, 1), shouldCompareWithInterfacePointer)
+	fail(t, so(reader, ShouldImplement, nil), shouldCompareWithInterfacePointer)
+
+	fail(t, so(nil, ShouldImplement, ioReader), shouldNotBeNilActual)
+	fail(t, so(1, ShouldImplement, ioReader), "Expected: 'io.Reader interface support'\nActual:   '*int' does not implement the interface!")
+
+	fail(t, so(response, ShouldImplement, ioReader), "Expected: 'io.Reader interface support'\nActual:   '*http.Response' does not implement the interface!")
+	fail(t, so(responsePtr, ShouldImplement, ioReader), "Expected: 'io.Reader interface support'\nActual:   '*http.Response' does not implement the interface!")
+	pass(t, so(reader, ShouldImplement, ioReader))
+	pass(t, so(reader, ShouldImplement, (*io.Reader)(nil)))
+}
+
+func TestShouldNotImplement(t *testing.T) {
+	var ioReader *io.Reader = nil
+	var response http.Response = http.Response{}
+	var responsePtr *http.Response = new(http.Response)
+	var reader io.Reader = bytes.NewBufferString("")
+
+	fail(t, so(reader, ShouldNotImplement), "This assertion requires exactly 1 comparison values (you provided 0).")
+	fail(t, so(reader, ShouldNotImplement, ioReader, ioReader), "This assertion requires exactly 1 comparison values (you provided 2).")
+	fail(t, so(reader, ShouldNotImplement, ioReader, ioReader, ioReader), "This assertion requires exactly 1 comparison values (you provided 3).")
+
+	fail(t, so(reader, ShouldNotImplement, "foo"), shouldCompareWithInterfacePointer)
+	fail(t, so(reader, ShouldNotImplement, 1), shouldCompareWithInterfacePointer)
+	fail(t, so(reader, ShouldNotImplement, nil), shouldCompareWithInterfacePointer)
+
+	fail(t, so(reader, ShouldNotImplement, ioReader), "Expected         '*bytes.Buffer'\nto NOT implement   'io.Reader' (but it did)!")
+	fail(t, so(nil, ShouldNotImplement, ioReader), shouldNotBeNilActual)
+	pass(t, so(1, ShouldNotImplement, ioReader))
+	pass(t, so(response, ShouldNotImplement, ioReader))
+	pass(t, so(responsePtr, ShouldNotImplement, ioReader))
+}

--- a/vendor/github.com/smartystreets/assertions/utilities_for_test.go
+++ b/vendor/github.com/smartystreets/assertions/utilities_for_test.go
@@ -1,0 +1,74 @@
+package assertions
+
+import (
+	"fmt"
+	"path"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func pass(t *testing.T, result string) {
+	if result != success {
+		_, file, line, _ := runtime.Caller(1)
+		base := path.Base(file)
+		t.Errorf("Expectation should have passed but failed (see %s: line %d): '%s'", base, line, result)
+	}
+}
+
+func fail(t *testing.T, actual string, expected string) {
+	actual = format(actual)
+	expected = format(expected)
+
+	if actual != expected {
+		if actual == "" {
+			actual = "(empty)"
+		}
+		_, file, line, _ := runtime.Caller(1)
+		t.Errorf("\n%s:%d\nExpected: %s\nActual:   %s\n",
+			file, line, expected, actual)
+	}
+}
+func format(message string) string {
+	message = strings.Replace(message, "\n", " ", -1)
+	for strings.Contains(message, "  ") {
+		message = strings.Replace(message, "  ", " ", -1)
+	}
+	return message
+}
+
+type Thing1 struct {
+	a string
+}
+type Thing2 struct {
+	a string
+}
+
+type Thinger interface {
+	Hi()
+}
+
+type Thing struct{}
+
+func (self *Thing) Hi() {}
+
+type IntAlias int
+type StringAlias string
+type StringSliceAlias []string
+type StringStringMapAlias map[string]string
+
+/******** FakeSerialzier ********/
+
+type fakeSerializer struct{}
+
+func (self *fakeSerializer) serialize(expected, actual interface{}, message string) string {
+	return fmt.Sprintf("%v|%v|%s", expected, actual, message)
+}
+
+func (self *fakeSerializer) serializeDetailed(expected, actual interface{}, message string) string {
+	return fmt.Sprintf("%v|%v|%s", expected, actual, message)
+}
+
+func newFakeSerializer() *fakeSerializer {
+	return new(fakeSerializer)
+}

--- a/vendor/github.com/smartystreets/goconvey/LICENSE.md
+++ b/vendor/github.com/smartystreets/goconvey/LICENSE.md
@@ -1,0 +1,23 @@
+Copyright (c) 2016 SmartyStreets, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+NOTE: Various optional and subordinate components carry their own licensing
+requirements and restrictions.  Use of those components is subject to the terms
+and conditions outlined the respective license of each component.

--- a/vendor/github.com/smartystreets/goconvey/convey/assertions.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/assertions.go
@@ -1,0 +1,68 @@
+package convey
+
+import "github.com/smartystreets/assertions"
+
+var (
+	ShouldEqual          = assertions.ShouldEqual
+	ShouldNotEqual       = assertions.ShouldNotEqual
+	ShouldAlmostEqual    = assertions.ShouldAlmostEqual
+	ShouldNotAlmostEqual = assertions.ShouldNotAlmostEqual
+	ShouldResemble       = assertions.ShouldResemble
+	ShouldNotResemble    = assertions.ShouldNotResemble
+	ShouldPointTo        = assertions.ShouldPointTo
+	ShouldNotPointTo     = assertions.ShouldNotPointTo
+	ShouldBeNil          = assertions.ShouldBeNil
+	ShouldNotBeNil       = assertions.ShouldNotBeNil
+	ShouldBeTrue         = assertions.ShouldBeTrue
+	ShouldBeFalse        = assertions.ShouldBeFalse
+	ShouldBeZeroValue    = assertions.ShouldBeZeroValue
+
+	ShouldBeGreaterThan          = assertions.ShouldBeGreaterThan
+	ShouldBeGreaterThanOrEqualTo = assertions.ShouldBeGreaterThanOrEqualTo
+	ShouldBeLessThan             = assertions.ShouldBeLessThan
+	ShouldBeLessThanOrEqualTo    = assertions.ShouldBeLessThanOrEqualTo
+	ShouldBeBetween              = assertions.ShouldBeBetween
+	ShouldNotBeBetween           = assertions.ShouldNotBeBetween
+	ShouldBeBetweenOrEqual       = assertions.ShouldBeBetweenOrEqual
+	ShouldNotBeBetweenOrEqual    = assertions.ShouldNotBeBetweenOrEqual
+
+	ShouldContain       = assertions.ShouldContain
+	ShouldNotContain    = assertions.ShouldNotContain
+	ShouldContainKey    = assertions.ShouldContainKey
+	ShouldNotContainKey = assertions.ShouldNotContainKey
+	ShouldBeIn          = assertions.ShouldBeIn
+	ShouldNotBeIn       = assertions.ShouldNotBeIn
+	ShouldBeEmpty       = assertions.ShouldBeEmpty
+	ShouldNotBeEmpty    = assertions.ShouldNotBeEmpty
+	ShouldHaveLength    = assertions.ShouldHaveLength
+
+	ShouldStartWith           = assertions.ShouldStartWith
+	ShouldNotStartWith        = assertions.ShouldNotStartWith
+	ShouldEndWith             = assertions.ShouldEndWith
+	ShouldNotEndWith          = assertions.ShouldNotEndWith
+	ShouldBeBlank             = assertions.ShouldBeBlank
+	ShouldNotBeBlank          = assertions.ShouldNotBeBlank
+	ShouldContainSubstring    = assertions.ShouldContainSubstring
+	ShouldNotContainSubstring = assertions.ShouldNotContainSubstring
+
+	ShouldPanic        = assertions.ShouldPanic
+	ShouldNotPanic     = assertions.ShouldNotPanic
+	ShouldPanicWith    = assertions.ShouldPanicWith
+	ShouldNotPanicWith = assertions.ShouldNotPanicWith
+
+	ShouldHaveSameTypeAs    = assertions.ShouldHaveSameTypeAs
+	ShouldNotHaveSameTypeAs = assertions.ShouldNotHaveSameTypeAs
+	ShouldImplement         = assertions.ShouldImplement
+	ShouldNotImplement      = assertions.ShouldNotImplement
+
+	ShouldHappenBefore         = assertions.ShouldHappenBefore
+	ShouldHappenOnOrBefore     = assertions.ShouldHappenOnOrBefore
+	ShouldHappenAfter          = assertions.ShouldHappenAfter
+	ShouldHappenOnOrAfter      = assertions.ShouldHappenOnOrAfter
+	ShouldHappenBetween        = assertions.ShouldHappenBetween
+	ShouldHappenOnOrBetween    = assertions.ShouldHappenOnOrBetween
+	ShouldNotHappenOnOrBetween = assertions.ShouldNotHappenOnOrBetween
+	ShouldHappenWithin         = assertions.ShouldHappenWithin
+	ShouldNotHappenWithin      = assertions.ShouldNotHappenWithin
+	ShouldBeChronological      = assertions.ShouldBeChronological
+)

--- a/vendor/github.com/smartystreets/goconvey/convey/context.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/context.go
@@ -1,0 +1,272 @@
+package convey
+
+import (
+	"fmt"
+
+	"github.com/jtolds/gls"
+	"github.com/smartystreets/goconvey/convey/reporting"
+)
+
+type conveyErr struct {
+	fmt    string
+	params []interface{}
+}
+
+func (e *conveyErr) Error() string {
+	return fmt.Sprintf(e.fmt, e.params...)
+}
+
+func conveyPanic(fmt string, params ...interface{}) {
+	panic(&conveyErr{fmt, params})
+}
+
+const (
+	missingGoTest = `Top-level calls to Convey(...) need a reference to the *testing.T.
+		Hint: Convey("description here", t, func() { /* notice that the second argument was the *testing.T (t)! */ }) `
+	extraGoTest    = `Only the top-level call to Convey(...) needs a reference to the *testing.T.`
+	noStackContext = "Convey operation made without context on goroutine stack.\n" +
+		"Hint: Perhaps you meant to use `Convey(..., func(c C){...})` ?"
+	differentConveySituations = "Different set of Convey statements on subsequent pass!\nDid not expect %#v."
+	multipleIdenticalConvey   = "Multiple convey suites with identical names: %#v"
+)
+
+const (
+	failureHalt = "___FAILURE_HALT___"
+
+	nodeKey = "node"
+)
+
+///////////////////////////////// Stack Context /////////////////////////////////
+
+func getCurrentContext() *context {
+	ctx, ok := ctxMgr.GetValue(nodeKey)
+	if ok {
+		return ctx.(*context)
+	}
+	return nil
+}
+
+func mustGetCurrentContext() *context {
+	ctx := getCurrentContext()
+	if ctx == nil {
+		conveyPanic(noStackContext)
+	}
+	return ctx
+}
+
+//////////////////////////////////// Context ////////////////////////////////////
+
+// context magically handles all coordination of Convey's and So assertions.
+//
+// It is tracked on the stack as goroutine-local-storage with the gls package,
+// or explicitly if the user decides to call convey like:
+//
+//   Convey(..., func(c C) {
+//     c.So(...)
+//   })
+//
+// This implements the `C` interface.
+type context struct {
+	reporter reporting.Reporter
+
+	children map[string]*context
+
+	resets []func()
+
+	executedOnce   bool
+	expectChildRun *bool
+	complete       bool
+
+	focus       bool
+	failureMode FailureMode
+}
+
+// rootConvey is the main entry point to a test suite. This is called when
+// there's no context in the stack already, and items must contain a `t` object,
+// or this panics.
+func rootConvey(items ...interface{}) {
+	entry := discover(items)
+
+	if entry.Test == nil {
+		conveyPanic(missingGoTest)
+	}
+
+	expectChildRun := true
+	ctx := &context{
+		reporter: buildReporter(),
+
+		children: make(map[string]*context),
+
+		expectChildRun: &expectChildRun,
+
+		focus:       entry.Focus,
+		failureMode: defaultFailureMode.combine(entry.FailMode),
+	}
+	ctxMgr.SetValues(gls.Values{nodeKey: ctx}, func() {
+		ctx.reporter.BeginStory(reporting.NewStoryReport(entry.Test))
+		defer ctx.reporter.EndStory()
+
+		for ctx.shouldVisit() {
+			ctx.conveyInner(entry.Situation, entry.Func)
+			expectChildRun = true
+		}
+	})
+}
+
+//////////////////////////////////// Methods ////////////////////////////////////
+
+func (ctx *context) SkipConvey(items ...interface{}) {
+	ctx.Convey(items, skipConvey)
+}
+
+func (ctx *context) FocusConvey(items ...interface{}) {
+	ctx.Convey(items, focusConvey)
+}
+
+func (ctx *context) Convey(items ...interface{}) {
+	entry := discover(items)
+
+	// we're a branch, or leaf (on the wind)
+	if entry.Test != nil {
+		conveyPanic(extraGoTest)
+	}
+	if ctx.focus && !entry.Focus {
+		return
+	}
+
+	var inner_ctx *context
+	if ctx.executedOnce {
+		var ok bool
+		inner_ctx, ok = ctx.children[entry.Situation]
+		if !ok {
+			conveyPanic(differentConveySituations, entry.Situation)
+		}
+	} else {
+		if _, ok := ctx.children[entry.Situation]; ok {
+			conveyPanic(multipleIdenticalConvey, entry.Situation)
+		}
+		inner_ctx = &context{
+			reporter: ctx.reporter,
+
+			children: make(map[string]*context),
+
+			expectChildRun: ctx.expectChildRun,
+
+			focus:       entry.Focus,
+			failureMode: ctx.failureMode.combine(entry.FailMode),
+		}
+		ctx.children[entry.Situation] = inner_ctx
+	}
+
+	if inner_ctx.shouldVisit() {
+		ctxMgr.SetValues(gls.Values{nodeKey: inner_ctx}, func() {
+			inner_ctx.conveyInner(entry.Situation, entry.Func)
+		})
+	}
+}
+
+func (ctx *context) SkipSo(stuff ...interface{}) {
+	ctx.assertionReport(reporting.NewSkipReport())
+}
+
+func (ctx *context) So(actual interface{}, assert assertion, expected ...interface{}) {
+	if result := assert(actual, expected...); result == assertionSuccess {
+		ctx.assertionReport(reporting.NewSuccessReport())
+	} else {
+		ctx.assertionReport(reporting.NewFailureReport(result))
+	}
+}
+
+func (ctx *context) Reset(action func()) {
+	/* TODO: Failure mode configuration */
+	ctx.resets = append(ctx.resets, action)
+}
+
+func (ctx *context) Print(items ...interface{}) (int, error) {
+	fmt.Fprint(ctx.reporter, items...)
+	return fmt.Print(items...)
+}
+
+func (ctx *context) Println(items ...interface{}) (int, error) {
+	fmt.Fprintln(ctx.reporter, items...)
+	return fmt.Println(items...)
+}
+
+func (ctx *context) Printf(format string, items ...interface{}) (int, error) {
+	fmt.Fprintf(ctx.reporter, format, items...)
+	return fmt.Printf(format, items...)
+}
+
+//////////////////////////////////// Private ////////////////////////////////////
+
+// shouldVisit returns true iff we should traverse down into a Convey. Note
+// that just because we don't traverse a Convey this time, doesn't mean that
+// we may not traverse it on a subsequent pass.
+func (c *context) shouldVisit() bool {
+	return !c.complete && *c.expectChildRun
+}
+
+// conveyInner is the function which actually executes the user's anonymous test
+// function body. At this point, Convey or RootConvey has decided that this
+// function should actually run.
+func (ctx *context) conveyInner(situation string, f func(C)) {
+	// Record/Reset state for next time.
+	defer func() {
+		ctx.executedOnce = true
+
+		// This is only needed at the leaves, but there's no harm in also setting it
+		// when returning from branch Convey's
+		*ctx.expectChildRun = false
+	}()
+
+	// Set up+tear down our scope for the reporter
+	ctx.reporter.Enter(reporting.NewScopeReport(situation))
+	defer ctx.reporter.Exit()
+
+	// Recover from any panics in f, and assign the `complete` status for this
+	// node of the tree.
+	defer func() {
+		ctx.complete = true
+		if problem := recover(); problem != nil {
+			if problem, ok := problem.(*conveyErr); ok {
+				panic(problem)
+			}
+			if problem != failureHalt {
+				ctx.reporter.Report(reporting.NewErrorReport(problem))
+			}
+		} else {
+			for _, child := range ctx.children {
+				if !child.complete {
+					ctx.complete = false
+					return
+				}
+			}
+		}
+	}()
+
+	// Resets are registered as the `f` function executes, so nil them here.
+	// All resets are run in registration order (FIFO).
+	ctx.resets = []func(){}
+	defer func() {
+		for _, r := range ctx.resets {
+			// panics handled by the previous defer
+			r()
+		}
+	}()
+
+	if f == nil {
+		// if f is nil, this was either a Convey(..., nil), or a SkipConvey
+		ctx.reporter.Report(reporting.NewSkipReport())
+	} else {
+		f(ctx)
+	}
+}
+
+// assertionReport is a helper for So and SkipSo which makes the report and
+// then possibly panics, depending on the current context's failureMode.
+func (ctx *context) assertionReport(r *reporting.AssertionResult) {
+	ctx.reporter.Report(r)
+	if r.Failure != "" && ctx.failureMode == FailureHalts {
+		panic(failureHalt)
+	}
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/convey.goconvey
+++ b/vendor/github.com/smartystreets/goconvey/convey/convey.goconvey
@@ -1,0 +1,4 @@
+#ignore
+-timeout=1s
+#-covermode=count
+#-coverpkg=github.com/smartystreets/goconvey/convey,github.com/smartystreets/goconvey/convey/gotest,github.com/smartystreets/goconvey/convey/reporting

--- a/vendor/github.com/smartystreets/goconvey/convey/discovery.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/discovery.go
@@ -1,0 +1,103 @@
+package convey
+
+type actionSpecifier uint8
+
+const (
+	noSpecifier actionSpecifier = iota
+	skipConvey
+	focusConvey
+)
+
+type suite struct {
+	Situation string
+	Test      t
+	Focus     bool
+	Func      func(C) // nil means skipped
+	FailMode  FailureMode
+}
+
+func newSuite(situation string, failureMode FailureMode, f func(C), test t, specifier actionSpecifier) *suite {
+	ret := &suite{
+		Situation: situation,
+		Test:      test,
+		Func:      f,
+		FailMode:  failureMode,
+	}
+	switch specifier {
+	case skipConvey:
+		ret.Func = nil
+	case focusConvey:
+		ret.Focus = true
+	}
+	return ret
+}
+
+func discover(items []interface{}) *suite {
+	name, items := parseName(items)
+	test, items := parseGoTest(items)
+	failure, items := parseFailureMode(items)
+	action, items := parseAction(items)
+	specifier, items := parseSpecifier(items)
+
+	if len(items) != 0 {
+		conveyPanic(parseError)
+	}
+
+	return newSuite(name, failure, action, test, specifier)
+}
+func item(items []interface{}) interface{} {
+	if len(items) == 0 {
+		conveyPanic(parseError)
+	}
+	return items[0]
+}
+func parseName(items []interface{}) (string, []interface{}) {
+	if name, parsed := item(items).(string); parsed {
+		return name, items[1:]
+	}
+	conveyPanic(parseError)
+	panic("never get here")
+}
+func parseGoTest(items []interface{}) (t, []interface{}) {
+	if test, parsed := item(items).(t); parsed {
+		return test, items[1:]
+	}
+	return nil, items
+}
+func parseFailureMode(items []interface{}) (FailureMode, []interface{}) {
+	if mode, parsed := item(items).(FailureMode); parsed {
+		return mode, items[1:]
+	}
+	return FailureInherits, items
+}
+func parseAction(items []interface{}) (func(C), []interface{}) {
+	switch x := item(items).(type) {
+	case nil:
+		return nil, items[1:]
+	case func(C):
+		return x, items[1:]
+	case func():
+		return func(C) { x() }, items[1:]
+	}
+	conveyPanic(parseError)
+	panic("never get here")
+}
+func parseSpecifier(items []interface{}) (actionSpecifier, []interface{}) {
+	if len(items) == 0 {
+		return noSpecifier, items
+	}
+	if spec, ok := items[0].(actionSpecifier); ok {
+		return spec, items[1:]
+	}
+	conveyPanic(parseError)
+	panic("never get here")
+}
+
+// This interface allows us to pass the *testing.T struct
+// throughout the internals of this package without ever
+// having to import the "testing" package.
+type t interface {
+	Fail()
+}
+
+const parseError = "You must provide a name (string), then a *testing.T (if in outermost scope), an optional FailureMode, and then an action (func())."

--- a/vendor/github.com/smartystreets/goconvey/convey/doc.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/doc.go
@@ -1,0 +1,218 @@
+// Package convey contains all of the public-facing entry points to this project.
+// This means that it should never be required of the user to import any other
+// packages from this project as they serve internal purposes.
+package convey
+
+import "github.com/smartystreets/goconvey/convey/reporting"
+
+////////////////////////////////// suite //////////////////////////////////
+
+// C is the Convey context which you can optionally obtain in your action
+// by calling Convey like:
+//
+//   Convey(..., func(c C) {
+//     ...
+//   })
+//
+// See the documentation on Convey for more details.
+//
+// All methods in this context behave identically to the global functions of the
+// same name in this package.
+type C interface {
+	Convey(items ...interface{})
+	SkipConvey(items ...interface{})
+	FocusConvey(items ...interface{})
+
+	So(actual interface{}, assert assertion, expected ...interface{})
+	SkipSo(stuff ...interface{})
+
+	Reset(action func())
+
+	Println(items ...interface{}) (int, error)
+	Print(items ...interface{}) (int, error)
+	Printf(format string, items ...interface{}) (int, error)
+}
+
+// Convey is the method intended for use when declaring the scopes of
+// a specification. Each scope has a description and a func() which may contain
+// other calls to Convey(), Reset() or Should-style assertions. Convey calls can
+// be nested as far as you see fit.
+//
+// IMPORTANT NOTE: The top-level Convey() within a Test method
+// must conform to the following signature:
+//
+//     Convey(description string, t *testing.T, action func())
+//
+// All other calls should look like this (no need to pass in *testing.T):
+//
+//     Convey(description string, action func())
+//
+// Don't worry, goconvey will panic if you get it wrong so you can fix it.
+//
+// Additionally, you may explicitly obtain access to the Convey context by doing:
+//
+//     Convey(description string, action func(c C))
+//
+// You may need to do this if you want to pass the context through to a
+// goroutine, or to close over the context in a handler to a library which
+// calls your handler in a goroutine (httptest comes to mind).
+//
+// All Convey()-blocks also accept an optional parameter of FailureMode which sets
+// how goconvey should treat failures for So()-assertions in the block and
+// nested blocks. See the constants in this file for the available options.
+//
+// By default it will inherit from its parent block and the top-level blocks
+// default to the FailureHalts setting.
+//
+// This parameter is inserted before the block itself:
+//
+//     Convey(description string, t *testing.T, mode FailureMode, action func())
+//     Convey(description string, mode FailureMode, action func())
+//
+// See the examples package for, well, examples.
+func Convey(items ...interface{}) {
+	if ctx := getCurrentContext(); ctx == nil {
+		rootConvey(items...)
+	} else {
+		ctx.Convey(items...)
+	}
+}
+
+// SkipConvey is analagous to Convey except that the scope is not executed
+// (which means that child scopes defined within this scope are not run either).
+// The reporter will be notified that this step was skipped.
+func SkipConvey(items ...interface{}) {
+	Convey(append(items, skipConvey)...)
+}
+
+// FocusConvey is has the inverse effect of SkipConvey. If the top-level
+// Convey is changed to `FocusConvey`, only nested scopes that are defined
+// with FocusConvey will be run. The rest will be ignored completely. This
+// is handy when debugging a large suite that runs a misbehaving function
+// repeatedly as you can disable all but one of that function
+// without swaths of `SkipConvey` calls, just a targeted chain of calls
+// to FocusConvey.
+func FocusConvey(items ...interface{}) {
+	Convey(append(items, focusConvey)...)
+}
+
+// Reset registers a cleanup function to be run after each Convey()
+// in the same scope. See the examples package for a simple use case.
+func Reset(action func()) {
+	mustGetCurrentContext().Reset(action)
+}
+
+/////////////////////////////////// Assertions ///////////////////////////////////
+
+// assertion is an alias for a function with a signature that the convey.So()
+// method can handle. Any future or custom assertions should conform to this
+// method signature. The return value should be an empty string if the assertion
+// passes and a well-formed failure message if not.
+type assertion func(actual interface{}, expected ...interface{}) string
+
+const assertionSuccess = ""
+
+// So is the means by which assertions are made against the system under test.
+// The majority of exported names in the assertions package begin with the word
+// 'Should' and describe how the first argument (actual) should compare with any
+// of the final (expected) arguments. How many final arguments are accepted
+// depends on the particular assertion that is passed in as the assert argument.
+// See the examples package for use cases and the assertions package for
+// documentation on specific assertion methods. A failing assertion will
+// cause t.Fail() to be invoked--you should never call this method (or other
+// failure-inducing methods) in your test code. Leave that to GoConvey.
+func So(actual interface{}, assert assertion, expected ...interface{}) {
+	mustGetCurrentContext().So(actual, assert, expected...)
+}
+
+// SkipSo is analagous to So except that the assertion that would have been passed
+// to So is not executed and the reporter is notified that the assertion was skipped.
+func SkipSo(stuff ...interface{}) {
+	mustGetCurrentContext().SkipSo()
+}
+
+// FailureMode is a type which determines how the So() blocks should fail
+// if their assertion fails. See constants further down for acceptable values
+type FailureMode string
+
+const (
+
+	// FailureContinues is a failure mode which prevents failing
+	// So()-assertions from halting Convey-block execution, instead
+	// allowing the test to continue past failing So()-assertions.
+	FailureContinues FailureMode = "continue"
+
+	// FailureHalts is the default setting for a top-level Convey()-block
+	// and will cause all failing So()-assertions to halt further execution
+	// in that test-arm and continue on to the next arm.
+	FailureHalts FailureMode = "halt"
+
+	// FailureInherits is the default setting for failure-mode, it will
+	// default to the failure-mode of the parent block. You should never
+	// need to specify this mode in your tests..
+	FailureInherits FailureMode = "inherits"
+)
+
+func (f FailureMode) combine(other FailureMode) FailureMode {
+	if other == FailureInherits {
+		return f
+	}
+	return other
+}
+
+var defaultFailureMode FailureMode = FailureHalts
+
+// SetDefaultFailureMode allows you to specify the default failure mode
+// for all Convey blocks. It is meant to be used in an init function to
+// allow the default mode to be changdd across all tests for an entire packgae
+// but it can be used anywhere.
+func SetDefaultFailureMode(mode FailureMode) {
+	if mode == FailureContinues || mode == FailureHalts {
+		defaultFailureMode = mode
+	} else {
+		panic("You may only use the constants named 'FailureContinues' and 'FailureHalts' as default failure modes.")
+	}
+}
+
+//////////////////////////////////// Print functions ////////////////////////////////////
+
+// Print is analogous to fmt.Print (and it even calls fmt.Print). It ensures that
+// output is aligned with the corresponding scopes in the web UI.
+func Print(items ...interface{}) (written int, err error) {
+	return mustGetCurrentContext().Print(items...)
+}
+
+// Print is analogous to fmt.Println (and it even calls fmt.Println). It ensures that
+// output is aligned with the corresponding scopes in the web UI.
+func Println(items ...interface{}) (written int, err error) {
+	return mustGetCurrentContext().Println(items...)
+}
+
+// Print is analogous to fmt.Printf (and it even calls fmt.Printf). It ensures that
+// output is aligned with the corresponding scopes in the web UI.
+func Printf(format string, items ...interface{}) (written int, err error) {
+	return mustGetCurrentContext().Printf(format, items...)
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+// SuppressConsoleStatistics prevents automatic printing of console statistics.
+// Calling PrintConsoleStatistics explicitly will force printing of statistics.
+func SuppressConsoleStatistics() {
+	reporting.SuppressConsoleStatistics()
+}
+
+// ConsoleStatistics may be called at any time to print assertion statistics.
+// Generally, the best place to do this would be in a TestMain function,
+// after all tests have been run. Something like this:
+//
+// func TestMain(m *testing.M) {
+//     convey.SuppressConsoleStatistics()
+//     result := m.Run()
+//     convey.PrintConsoleStatistics()
+//     os.Exit(result)
+// }
+//
+func PrintConsoleStatistics() {
+	reporting.PrintConsoleStatistics()
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/focused_execution_test.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/focused_execution_test.go
@@ -1,0 +1,72 @@
+package convey
+
+import "testing"
+
+func TestFocusOnlyAtTopLevel(t *testing.T) {
+	output := prepare()
+
+	FocusConvey("hi", t, func() {
+		output += "done"
+	})
+
+	expectEqual(t, "done", output)
+}
+
+func TestFocus(t *testing.T) {
+	output := prepare()
+
+	FocusConvey("hi", t, func() {
+		output += "1"
+
+		Convey("bye", func() {
+			output += "2"
+		})
+	})
+
+	expectEqual(t, "1", output)
+}
+
+func TestNestedFocus(t *testing.T) {
+	output := prepare()
+
+	FocusConvey("hi", t, func() {
+		output += "1"
+
+		Convey("This shouldn't run", func() {
+			output += "boink!"
+		})
+
+		FocusConvey("This should run", func() {
+			output += "2"
+
+			FocusConvey("The should run too", func() {
+				output += "3"
+
+			})
+
+			Convey("The should NOT run", func() {
+				output += "blah blah blah!"
+			})
+		})
+	})
+
+	expectEqual(t, "123", output)
+}
+
+func TestForgotTopLevelFocus(t *testing.T) {
+	output := prepare()
+
+	Convey("1", t, func() {
+		output += "1"
+
+		FocusConvey("This will be run because the top-level lacks Focus", func() {
+			output += "2"
+		})
+
+		Convey("3", func() {
+			output += "3"
+		})
+	})
+
+	expectEqual(t, "1213", output)
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/gotest/doc_test.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/gotest/doc_test.go
@@ -1,0 +1,1 @@
+package gotest

--- a/vendor/github.com/smartystreets/goconvey/convey/gotest/utils.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/gotest/utils.go
@@ -1,0 +1,28 @@
+// Package gotest contains internal functionality. Although this package
+// contains one or more exported names it is not intended for public
+// consumption. See the examples package for how to use this project.
+package gotest
+
+import (
+	"runtime"
+	"strings"
+)
+
+func ResolveExternalCaller() (file string, line int, name string) {
+	var caller_id uintptr
+	callers := runtime.Callers(0, callStack)
+
+	for x := 0; x < callers; x++ {
+		caller_id, file, line, _ = runtime.Caller(x)
+		if strings.HasSuffix(file, "_test.go") || strings.HasSuffix(file, "_tests.go") {
+			name = runtime.FuncForPC(caller_id).Name()
+			return
+		}
+	}
+	file, line, name = "<unkown file>", -1, "<unknown name>"
+	return // panic?
+}
+
+const maxStackDepth = 100 // This had better be enough...
+
+var callStack []uintptr = make([]uintptr, maxStackDepth, maxStackDepth)

--- a/vendor/github.com/smartystreets/goconvey/convey/init.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/init.go
@@ -1,0 +1,81 @@
+package convey
+
+import (
+	"flag"
+	"os"
+
+	"github.com/jtolds/gls"
+	"github.com/smartystreets/assertions"
+	"github.com/smartystreets/goconvey/convey/reporting"
+)
+
+func init() {
+	assertions.GoConveyMode(true)
+
+	declareFlags()
+
+	ctxMgr = gls.NewContextManager()
+}
+
+func declareFlags() {
+	flag.BoolVar(&json, "convey-json", false, "When true, emits results in JSON blocks. Default: 'false'")
+	flag.BoolVar(&silent, "convey-silent", false, "When true, all output from GoConvey is suppressed.")
+	flag.BoolVar(&story, "convey-story", false, "When true, emits story output, otherwise emits dot output. When not provided, this flag mirros the value of the '-test.v' flag")
+
+	if noStoryFlagProvided() {
+		story = verboseEnabled
+	}
+
+	// FYI: flag.Parse() is called from the testing package.
+}
+
+func noStoryFlagProvided() bool {
+	return !story && !storyDisabled
+}
+
+func buildReporter() reporting.Reporter {
+	selectReporter := os.Getenv("GOCONVEY_REPORTER")
+
+	switch {
+	case testReporter != nil:
+		return testReporter
+	case json || selectReporter == "json":
+		return reporting.BuildJsonReporter()
+	case silent || selectReporter == "silent":
+		return reporting.BuildSilentReporter()
+	case selectReporter == "dot":
+		// Story is turned on when verbose is set, so we need to check for dot reporter first.
+		return reporting.BuildDotReporter()
+	case story || selectReporter == "story":
+		return reporting.BuildStoryReporter()
+	default:
+		return reporting.BuildDotReporter()
+	}
+}
+
+var (
+	ctxMgr *gls.ContextManager
+
+	// only set by internal tests
+	testReporter reporting.Reporter
+)
+
+var (
+	json   bool
+	silent bool
+	story  bool
+
+	verboseEnabled = flagFound("-test.v=true")
+	storyDisabled  = flagFound("-story=false")
+)
+
+// flagFound parses the command line args manually for flags defined in other
+// packages. Like the '-v' flag from the "testing" package, for instance.
+func flagFound(flagValue string) bool {
+	for _, arg := range os.Args {
+		if arg == flagValue {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/isolated_execution_test.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/isolated_execution_test.go
@@ -1,0 +1,774 @@
+package convey
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestSingleScope(t *testing.T) {
+	output := prepare()
+
+	Convey("hi", t, func() {
+		output += "done"
+	})
+
+	expectEqual(t, "done", output)
+}
+
+func TestSingleScopeWithMultipleConveys(t *testing.T) {
+	output := prepare()
+
+	Convey("1", t, func() {
+		output += "1"
+	})
+
+	Convey("2", t, func() {
+		output += "2"
+	})
+
+	expectEqual(t, "12", output)
+}
+
+func TestNestedScopes(t *testing.T) {
+	output := prepare()
+
+	Convey("a", t, func() {
+		output += "a "
+
+		Convey("bb", func() {
+			output += "bb "
+
+			Convey("ccc", func() {
+				output += "ccc | "
+			})
+		})
+	})
+
+	expectEqual(t, "a bb ccc | ", output)
+}
+
+func TestNestedScopesWithIsolatedExecution(t *testing.T) {
+	output := prepare()
+
+	Convey("a", t, func() {
+		output += "a "
+
+		Convey("aa", func() {
+			output += "aa "
+
+			Convey("aaa", func() {
+				output += "aaa | "
+			})
+
+			Convey("aaa1", func() {
+				output += "aaa1 | "
+			})
+		})
+
+		Convey("ab", func() {
+			output += "ab "
+
+			Convey("abb", func() {
+				output += "abb | "
+			})
+		})
+	})
+
+	expectEqual(t, "a aa aaa | a aa aaa1 | a ab abb | ", output)
+}
+
+func TestSingleScopeWithConveyAndNestedReset(t *testing.T) {
+	output := prepare()
+
+	Convey("1", t, func() {
+		output += "1"
+
+		Reset(func() {
+			output += "a"
+		})
+	})
+
+	expectEqual(t, "1a", output)
+}
+
+func TestPanicingReset(t *testing.T) {
+	output := prepare()
+
+	Convey("1", t, func() {
+		output += "1"
+
+		Reset(func() {
+			panic("nooo")
+		})
+
+		Convey("runs since the reset hasn't yet", func() {
+			output += "a"
+		})
+
+		Convey("but this doesnt", func() {
+			output += "nope"
+		})
+	})
+
+	expectEqual(t, "1a", output)
+}
+
+func TestSingleScopeWithMultipleRegistrationsAndReset(t *testing.T) {
+	output := prepare()
+
+	Convey("reset after each nested convey", t, func() {
+		Convey("first output", func() {
+			output += "1"
+		})
+
+		Convey("second output", func() {
+			output += "2"
+		})
+
+		Reset(func() {
+			output += "a"
+		})
+	})
+
+	expectEqual(t, "1a2a", output)
+}
+
+func TestSingleScopeWithMultipleRegistrationsAndMultipleResets(t *testing.T) {
+	output := prepare()
+
+	Convey("each reset is run at end of each nested convey", t, func() {
+		Convey("1", func() {
+			output += "1"
+		})
+
+		Convey("2", func() {
+			output += "2"
+		})
+
+		Reset(func() {
+			output += "a"
+		})
+
+		Reset(func() {
+			output += "b"
+		})
+	})
+
+	expectEqual(t, "1ab2ab", output)
+}
+
+func Test_Failure_AtHigherLevelScopePreventsChildScopesFromRunning(t *testing.T) {
+	output := prepare()
+
+	Convey("This step fails", t, func() {
+		So(1, ShouldEqual, 2)
+
+		Convey("this should NOT be executed", func() {
+			output += "a"
+		})
+	})
+
+	expectEqual(t, "", output)
+}
+
+func Test_Panic_AtHigherLevelScopePreventsChildScopesFromRunning(t *testing.T) {
+	output := prepare()
+
+	Convey("This step panics", t, func() {
+		Convey("this happens, because the panic didn't happen yet", func() {
+			output += "1"
+		})
+
+		output += "a"
+
+		Convey("this should NOT be executed", func() {
+			output += "2"
+		})
+
+		output += "b"
+
+		panic("Hi")
+
+		output += "nope"
+	})
+
+	expectEqual(t, "1ab", output)
+}
+
+func Test_Panic_InChildScopeDoes_NOT_PreventExecutionOfSiblingScopes(t *testing.T) {
+	output := prepare()
+
+	Convey("This is the parent", t, func() {
+		Convey("This step panics", func() {
+			panic("Hi")
+			output += "1"
+		})
+
+		Convey("This sibling should execute", func() {
+			output += "2"
+		})
+	})
+
+	expectEqual(t, "2", output)
+}
+
+func Test_Failure_InChildScopeDoes_NOT_PreventExecutionOfSiblingScopes(t *testing.T) {
+	output := prepare()
+
+	Convey("This is the parent", t, func() {
+		Convey("This step fails", func() {
+			So(1, ShouldEqual, 2)
+			output += "1"
+		})
+
+		Convey("This sibling should execute", func() {
+			output += "2"
+		})
+	})
+
+	expectEqual(t, "2", output)
+}
+
+func TestResetsAreAlwaysExecutedAfterScope_Panics(t *testing.T) {
+	output := prepare()
+
+	Convey("This is the parent", t, func() {
+		Convey("This step panics", func() {
+			panic("Hi")
+			output += "1"
+		})
+
+		Convey("This sibling step does not panic", func() {
+			output += "a"
+
+			Reset(func() {
+				output += "b"
+			})
+		})
+
+		Reset(func() {
+			output += "2"
+		})
+	})
+
+	expectEqual(t, "2ab2", output)
+}
+
+func TestResetsAreAlwaysExecutedAfterScope_Failures(t *testing.T) {
+	output := prepare()
+
+	Convey("This is the parent", t, func() {
+		Convey("This step fails", func() {
+			So(1, ShouldEqual, 2)
+			output += "1"
+		})
+
+		Convey("This sibling step does not fail", func() {
+			output += "a"
+
+			Reset(func() {
+				output += "b"
+			})
+		})
+
+		Reset(func() {
+			output += "2"
+		})
+	})
+
+	expectEqual(t, "2ab2", output)
+}
+
+func TestSkipTopLevel(t *testing.T) {
+	output := prepare()
+
+	SkipConvey("hi", t, func() {
+		output += "This shouldn't be executed!"
+	})
+
+	expectEqual(t, "", output)
+}
+
+func TestSkipNestedLevel(t *testing.T) {
+	output := prepare()
+
+	Convey("hi", t, func() {
+		output += "yes"
+
+		SkipConvey("bye", func() {
+			output += "no"
+		})
+	})
+
+	expectEqual(t, "yes", output)
+}
+
+func TestSkipNestedLevelSkipsAllChildLevels(t *testing.T) {
+	output := prepare()
+
+	Convey("hi", t, func() {
+		output += "yes"
+
+		SkipConvey("bye", func() {
+			output += "no"
+
+			Convey("byebye", func() {
+				output += "no-no"
+			})
+		})
+	})
+
+	expectEqual(t, "yes", output)
+}
+
+func TestIterativeConveys(t *testing.T) {
+	output := prepare()
+
+	Convey("Test", t, func() {
+		for x := 0; x < 10; x++ {
+			y := strconv.Itoa(x)
+
+			Convey(y, func() {
+				output += y
+			})
+		}
+	})
+
+	expectEqual(t, "0123456789", output)
+}
+
+func TestClosureVariables(t *testing.T) {
+	output := prepare()
+
+	i := 0
+
+	Convey("A", t, func() {
+		i = i + 1
+		j := i
+
+		output += "A" + strconv.Itoa(i) + " "
+
+		Convey("B", func() {
+			k := j
+			j = j + 1
+
+			output += "B" + strconv.Itoa(k) + " "
+
+			Convey("C", func() {
+				output += "C" + strconv.Itoa(k) + strconv.Itoa(j) + " "
+			})
+
+			Convey("D", func() {
+				output += "D" + strconv.Itoa(k) + strconv.Itoa(j) + " "
+			})
+		})
+
+		Convey("C", func() {
+			output += "C" + strconv.Itoa(j) + " "
+		})
+	})
+
+	output += "D" + strconv.Itoa(i) + " "
+
+	expectEqual(t, "A1 B1 C12 A2 B2 D23 A3 C3 D3 ", output)
+}
+
+func TestClosureVariablesWithReset(t *testing.T) {
+	output := prepare()
+
+	i := 0
+
+	Convey("A", t, func() {
+		i = i + 1
+		j := i
+
+		output += "A" + strconv.Itoa(i) + " "
+
+		Reset(func() {
+			output += "R" + strconv.Itoa(i) + strconv.Itoa(j) + " "
+		})
+
+		Convey("B", func() {
+			output += "B" + strconv.Itoa(j) + " "
+		})
+
+		Convey("C", func() {
+			output += "C" + strconv.Itoa(j) + " "
+		})
+	})
+
+	output += "D" + strconv.Itoa(i) + " "
+
+	expectEqual(t, "A1 B1 R11 A2 C2 R22 D2 ", output)
+}
+
+func TestWrappedSimple(t *testing.T) {
+	prepare()
+	output := resetTestString{""}
+
+	Convey("A", t, func() {
+		func() {
+			output.output += "A "
+
+			Convey("B", func() {
+				output.output += "B "
+
+				Convey("C", func() {
+					output.output += "C "
+				})
+
+			})
+
+			Convey("D", func() {
+				output.output += "D "
+			})
+		}()
+	})
+
+	expectEqual(t, "A B C A D ", output.output)
+}
+
+type resetTestString struct {
+	output string
+}
+
+func addReset(o *resetTestString, f func()) func() {
+	return func() {
+		Reset(func() {
+			o.output += "R "
+		})
+
+		f()
+	}
+}
+
+func TestWrappedReset(t *testing.T) {
+	prepare()
+	output := resetTestString{""}
+
+	Convey("A", t, addReset(&output, func() {
+		output.output += "A "
+
+		Convey("B", func() {
+			output.output += "B "
+		})
+
+		Convey("C", func() {
+			output.output += "C "
+		})
+	}))
+
+	expectEqual(t, "A B R A C R ", output.output)
+}
+
+func TestWrappedReset2(t *testing.T) {
+	prepare()
+	output := resetTestString{""}
+
+	Convey("A", t, func() {
+		Reset(func() {
+			output.output += "R "
+		})
+
+		func() {
+			output.output += "A "
+
+			Convey("B", func() {
+				output.output += "B "
+
+				Convey("C", func() {
+					output.output += "C "
+				})
+			})
+
+			Convey("D", func() {
+				output.output += "D "
+			})
+		}()
+	})
+
+	expectEqual(t, "A B C R A D R ", output.output)
+}
+
+func TestInfiniteLoopWithTrailingFail(t *testing.T) {
+	done := make(chan int)
+
+	go func() {
+		Convey("This fails", t, func() {
+			Convey("and this is run", func() {
+				So(true, ShouldEqual, true)
+			})
+
+			/* And this prevents the whole block to be marked as run */
+			So(false, ShouldEqual, true)
+		})
+
+		done <- 1
+	}()
+
+	select {
+	case <-done:
+		return
+	case <-time.After(1 * time.Millisecond):
+		t.Fail()
+	}
+}
+
+func TestOutermostResetInvokedForGrandchildren(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, func() {
+		output += "A "
+
+		Reset(func() {
+			output += "rA "
+		})
+
+		Convey("B", func() {
+			output += "B "
+
+			Reset(func() {
+				output += "rB "
+			})
+
+			Convey("C", func() {
+				output += "C "
+
+				Reset(func() {
+					output += "rC "
+				})
+			})
+
+			Convey("D", func() {
+				output += "D "
+
+				Reset(func() {
+					output += "rD "
+				})
+			})
+		})
+	})
+
+	expectEqual(t, "A B C rC rB rA A B D rD rB rA ", output)
+}
+
+func TestFailureOption(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, FailureHalts, func() {
+		output += "A "
+		So(true, ShouldEqual, true)
+		output += "B "
+		So(false, ShouldEqual, true)
+		output += "C "
+	})
+
+	expectEqual(t, "A B ", output)
+}
+
+func TestFailureOption2(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, func() {
+		output += "A "
+		So(true, ShouldEqual, true)
+		output += "B "
+		So(false, ShouldEqual, true)
+		output += "C "
+	})
+
+	expectEqual(t, "A B ", output)
+}
+
+func TestFailureOption3(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, FailureContinues, func() {
+		output += "A "
+		So(true, ShouldEqual, true)
+		output += "B "
+		So(false, ShouldEqual, true)
+		output += "C "
+	})
+
+	expectEqual(t, "A B C ", output)
+}
+
+func TestFailureOptionInherit(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, FailureContinues, func() {
+		output += "A1 "
+		So(false, ShouldEqual, true)
+		output += "A2 "
+
+		Convey("B", func() {
+			output += "B1 "
+			So(true, ShouldEqual, true)
+			output += "B2 "
+			So(false, ShouldEqual, true)
+			output += "B3 "
+		})
+	})
+
+	expectEqual(t, "A1 A2 B1 B2 B3 ", output)
+}
+
+func TestFailureOptionInherit2(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, FailureHalts, func() {
+		output += "A1 "
+		So(false, ShouldEqual, true)
+		output += "A2 "
+
+		Convey("B", func() {
+			output += "A1 "
+			So(true, ShouldEqual, true)
+			output += "A2 "
+			So(false, ShouldEqual, true)
+			output += "A3 "
+		})
+	})
+
+	expectEqual(t, "A1 ", output)
+}
+
+func TestFailureOptionInherit3(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, FailureHalts, func() {
+		output += "A1 "
+		So(true, ShouldEqual, true)
+		output += "A2 "
+
+		Convey("B", func() {
+			output += "B1 "
+			So(true, ShouldEqual, true)
+			output += "B2 "
+			So(false, ShouldEqual, true)
+			output += "B3 "
+		})
+	})
+
+	expectEqual(t, "A1 A2 B1 B2 ", output)
+}
+
+func TestFailureOptionNestedOverride(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, FailureContinues, func() {
+		output += "A "
+		So(false, ShouldEqual, true)
+		output += "B "
+
+		Convey("C", FailureHalts, func() {
+			output += "C "
+			So(true, ShouldEqual, true)
+			output += "D "
+			So(false, ShouldEqual, true)
+			output += "E "
+		})
+	})
+
+	expectEqual(t, "A B C D ", output)
+}
+
+func TestFailureOptionNestedOverride2(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, FailureHalts, func() {
+		output += "A "
+		So(true, ShouldEqual, true)
+		output += "B "
+
+		Convey("C", FailureContinues, func() {
+			output += "C "
+			So(true, ShouldEqual, true)
+			output += "D "
+			So(false, ShouldEqual, true)
+			output += "E "
+		})
+	})
+
+	expectEqual(t, "A B C D E ", output)
+}
+
+func TestMultipleInvocationInheritance(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, FailureHalts, func() {
+		output += "A1 "
+		So(true, ShouldEqual, true)
+		output += "A2 "
+
+		Convey("B", FailureContinues, func() {
+			output += "B1 "
+			So(true, ShouldEqual, true)
+			output += "B2 "
+			So(false, ShouldEqual, true)
+			output += "B3 "
+		})
+
+		Convey("C", func() {
+			output += "C1 "
+			So(true, ShouldEqual, true)
+			output += "C2 "
+			So(false, ShouldEqual, true)
+			output += "C3 "
+		})
+	})
+
+	expectEqual(t, "A1 A2 B1 B2 B3 A1 A2 C1 C2 ", output)
+}
+
+func TestMultipleInvocationInheritance2(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, FailureContinues, func() {
+		output += "A1 "
+		So(true, ShouldEqual, true)
+		output += "A2 "
+		So(false, ShouldEqual, true)
+		output += "A3 "
+
+		Convey("B", FailureHalts, func() {
+			output += "B1 "
+			So(true, ShouldEqual, true)
+			output += "B2 "
+			So(false, ShouldEqual, true)
+			output += "B3 "
+		})
+
+		Convey("C", func() {
+			output += "C1 "
+			So(true, ShouldEqual, true)
+			output += "C2 "
+			So(false, ShouldEqual, true)
+			output += "C3 "
+		})
+	})
+
+	expectEqual(t, "A1 A2 A3 B1 B2 A1 A2 A3 C1 C2 C3 ", output)
+}
+
+func TestSetDefaultFailureMode(t *testing.T) {
+	output := prepare()
+
+	SetDefaultFailureMode(FailureContinues) // the default is normally FailureHalts
+	defer SetDefaultFailureMode(FailureHalts)
+
+	Convey("A", t, func() {
+		output += "A1 "
+		So(true, ShouldBeFalse)
+		output += "A2 "
+	})
+
+	expectEqual(t, "A1 A2 ", output)
+}
+
+func prepare() string {
+	testReporter = newNilReporter()
+	return ""
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/nilReporter.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/nilReporter.go
@@ -1,0 +1,15 @@
+package convey
+
+import (
+	"github.com/smartystreets/goconvey/convey/reporting"
+)
+
+type nilReporter struct{}
+
+func (self *nilReporter) BeginStory(story *reporting.StoryReport)  {}
+func (self *nilReporter) Enter(scope *reporting.ScopeReport)       {}
+func (self *nilReporter) Report(report *reporting.AssertionResult) {}
+func (self *nilReporter) Exit()                                    {}
+func (self *nilReporter) EndStory()                                {}
+func (self *nilReporter) Write(p []byte) (int, error)              { return len(p), nil }
+func newNilReporter() *nilReporter                                 { return &nilReporter{} }

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/console.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/console.go
@@ -1,0 +1,16 @@
+package reporting
+
+import (
+	"fmt"
+	"io"
+)
+
+type console struct{}
+
+func (self *console) Write(p []byte) (n int, err error) {
+	return fmt.Print(string(p))
+}
+
+func NewConsole() io.Writer {
+	return new(console)
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/doc.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/doc.go
@@ -1,0 +1,5 @@
+// Package reporting contains internal functionality related
+// to console reporting and output. Although this package has
+// exported names is not intended for public consumption. See the
+// examples package for how to use this project.
+package reporting

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/dot.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/dot.go
@@ -1,0 +1,40 @@
+package reporting
+
+import "fmt"
+
+type dot struct{ out *Printer }
+
+func (self *dot) BeginStory(story *StoryReport) {}
+
+func (self *dot) Enter(scope *ScopeReport) {}
+
+func (self *dot) Report(report *AssertionResult) {
+	if report.Error != nil {
+		fmt.Print(redColor)
+		self.out.Insert(dotError)
+	} else if report.Failure != "" {
+		fmt.Print(yellowColor)
+		self.out.Insert(dotFailure)
+	} else if report.Skipped {
+		fmt.Print(yellowColor)
+		self.out.Insert(dotSkip)
+	} else {
+		fmt.Print(greenColor)
+		self.out.Insert(dotSuccess)
+	}
+	fmt.Print(resetColor)
+}
+
+func (self *dot) Exit() {}
+
+func (self *dot) EndStory() {}
+
+func (self *dot) Write(content []byte) (written int, err error) {
+	return len(content), nil // no-op
+}
+
+func NewDotReporter(out *Printer) *dot {
+	self := new(dot)
+	self.out = out
+	return self
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/dot_test.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/dot_test.go
@@ -1,0 +1,40 @@
+package reporting
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDotReporterAssertionPrinting(t *testing.T) {
+	monochrome()
+	file := newMemoryFile()
+	printer := NewPrinter(file)
+	reporter := NewDotReporter(printer)
+
+	reporter.Report(NewSuccessReport())
+	reporter.Report(NewFailureReport("failed"))
+	reporter.Report(NewErrorReport(errors.New("error")))
+	reporter.Report(NewSkipReport())
+
+	expected := dotSuccess + dotFailure + dotError + dotSkip
+
+	if file.buffer != expected {
+		t.Errorf("\nExpected: '%s'\nActual:  '%s'", expected, file.buffer)
+	}
+}
+
+func TestDotReporterOnlyReportsAssertions(t *testing.T) {
+	monochrome()
+	file := newMemoryFile()
+	printer := NewPrinter(file)
+	reporter := NewDotReporter(printer)
+
+	reporter.BeginStory(nil)
+	reporter.Enter(nil)
+	reporter.Exit()
+	reporter.EndStory()
+
+	if file.buffer != "" {
+		t.Errorf("\nExpected: '(blank)'\nActual:  '%s'", file.buffer)
+	}
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/gotest.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/gotest.go
@@ -1,0 +1,33 @@
+package reporting
+
+type gotestReporter struct{ test T }
+
+func (self *gotestReporter) BeginStory(story *StoryReport) {
+	self.test = story.Test
+}
+
+func (self *gotestReporter) Enter(scope *ScopeReport) {}
+
+func (self *gotestReporter) Report(r *AssertionResult) {
+	if !passed(r) {
+		self.test.Fail()
+	}
+}
+
+func (self *gotestReporter) Exit() {}
+
+func (self *gotestReporter) EndStory() {
+	self.test = nil
+}
+
+func (self *gotestReporter) Write(content []byte) (written int, err error) {
+	return len(content), nil // no-op
+}
+
+func NewGoTestReporter() *gotestReporter {
+	return new(gotestReporter)
+}
+
+func passed(r *AssertionResult) bool {
+	return r.Error == nil && r.Failure == ""
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/gotest_test.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/gotest_test.go
@@ -1,0 +1,66 @@
+package reporting
+
+import "testing"
+
+func TestReporterReceivesSuccessfulReport(t *testing.T) {
+	reporter := NewGoTestReporter()
+	test := new(fakeTest)
+	reporter.BeginStory(NewStoryReport(test))
+	reporter.Report(NewSuccessReport())
+
+	if test.failed {
+		t.Errorf("Should have have marked test as failed--the report reflected success.")
+	}
+}
+
+func TestReporterReceivesFailureReport(t *testing.T) {
+	reporter := NewGoTestReporter()
+	test := new(fakeTest)
+	reporter.BeginStory(NewStoryReport(test))
+	reporter.Report(NewFailureReport("This is a failure."))
+
+	if !test.failed {
+		t.Errorf("Test should have been marked as failed (but it wasn't).")
+	}
+}
+
+func TestReporterReceivesErrorReport(t *testing.T) {
+	reporter := NewGoTestReporter()
+	test := new(fakeTest)
+	reporter.BeginStory(NewStoryReport(test))
+	reporter.Report(NewErrorReport("This is an error."))
+
+	if !test.failed {
+		t.Errorf("Test should have been marked as failed (but it wasn't).")
+	}
+}
+
+func TestReporterIsResetAtTheEndOfTheStory(t *testing.T) {
+	defer catch(t)
+	reporter := NewGoTestReporter()
+	test := new(fakeTest)
+	reporter.BeginStory(NewStoryReport(test))
+	reporter.EndStory()
+
+	reporter.Report(NewSuccessReport())
+}
+
+func TestReporterNoopMethods(t *testing.T) {
+	reporter := NewGoTestReporter()
+	reporter.Enter(NewScopeReport("title"))
+	reporter.Exit()
+}
+
+func catch(t *testing.T) {
+	if r := recover(); r != nil {
+		t.Log("Getting to this point means we've passed (because we caught a panic appropriately).")
+	}
+}
+
+type fakeTest struct {
+	failed bool
+}
+
+func (self *fakeTest) Fail() {
+	self.failed = true
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/init.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/init.go
@@ -1,0 +1,94 @@
+package reporting
+
+import (
+	"os"
+	"runtime"
+	"strings"
+)
+
+func init() {
+	if !isColorableTerminal() {
+		monochrome()
+	}
+
+	if runtime.GOOS == "windows" {
+		success, failure, error_ = dotSuccess, dotFailure, dotError
+	}
+}
+
+func BuildJsonReporter() Reporter {
+	out := NewPrinter(NewConsole())
+	return NewReporters(
+		NewGoTestReporter(),
+		NewJsonReporter(out))
+}
+func BuildDotReporter() Reporter {
+	out := NewPrinter(NewConsole())
+	return NewReporters(
+		NewGoTestReporter(),
+		NewDotReporter(out),
+		NewProblemReporter(out),
+		consoleStatistics)
+}
+func BuildStoryReporter() Reporter {
+	out := NewPrinter(NewConsole())
+	return NewReporters(
+		NewGoTestReporter(),
+		NewStoryReporter(out),
+		NewProblemReporter(out),
+		consoleStatistics)
+}
+func BuildSilentReporter() Reporter {
+	out := NewPrinter(NewConsole())
+	return NewReporters(
+		NewGoTestReporter(),
+		NewSilentProblemReporter(out))
+}
+
+var (
+	newline         = "\n"
+	success         = "✔"
+	failure         = "✘"
+	error_          = "🔥"
+	skip            = "⚠"
+	dotSuccess      = "."
+	dotFailure      = "x"
+	dotError        = "E"
+	dotSkip         = "S"
+	errorTemplate   = "* %s \nLine %d: - %v \n%s\n"
+	failureTemplate = "* %s \nLine %d:\n%s\n"
+)
+
+var (
+	greenColor  = "\033[32m"
+	yellowColor = "\033[33m"
+	redColor    = "\033[31m"
+	resetColor  = "\033[0m"
+)
+
+var consoleStatistics = NewStatisticsReporter(NewPrinter(NewConsole()))
+
+func SuppressConsoleStatistics() { consoleStatistics.Suppress() }
+func PrintConsoleStatistics()    { consoleStatistics.PrintSummary() }
+
+// QuiteMode disables all console output symbols. This is only meant to be used
+// for tests that are internal to goconvey where the output is distracting or
+// otherwise not needed in the test output.
+func QuietMode() {
+	success, failure, error_, skip, dotSuccess, dotFailure, dotError, dotSkip = "", "", "", "", "", "", "", ""
+}
+
+func monochrome() {
+	greenColor, yellowColor, redColor, resetColor = "", "", "", ""
+}
+
+func isColorableTerminal() bool {
+	return strings.Contains(os.Getenv("TERM"), "color")
+}
+
+// This interface allows us to pass the *testing.T struct
+// throughout the internals of this tool without ever
+// having to import the "testing" package.
+type T interface {
+	Fail()
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/json.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/json.go
@@ -1,0 +1,88 @@
+// TODO: under unit test
+
+package reporting
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type JsonReporter struct {
+	out        *Printer
+	currentKey []string
+	current    *ScopeResult
+	index      map[string]*ScopeResult
+	scopes     []*ScopeResult
+}
+
+func (self *JsonReporter) depth() int { return len(self.currentKey) }
+
+func (self *JsonReporter) BeginStory(story *StoryReport) {}
+
+func (self *JsonReporter) Enter(scope *ScopeReport) {
+	self.currentKey = append(self.currentKey, scope.Title)
+	ID := strings.Join(self.currentKey, "|")
+	if _, found := self.index[ID]; !found {
+		next := newScopeResult(scope.Title, self.depth(), scope.File, scope.Line)
+		self.scopes = append(self.scopes, next)
+		self.index[ID] = next
+	}
+	self.current = self.index[ID]
+}
+
+func (self *JsonReporter) Report(report *AssertionResult) {
+	self.current.Assertions = append(self.current.Assertions, report)
+}
+
+func (self *JsonReporter) Exit() {
+	self.currentKey = self.currentKey[:len(self.currentKey)-1]
+}
+
+func (self *JsonReporter) EndStory() {
+	self.report()
+	self.reset()
+}
+func (self *JsonReporter) report() {
+	scopes := []string{}
+	for _, scope := range self.scopes {
+		serialized, err := json.Marshal(scope)
+		if err != nil {
+			self.out.Println(jsonMarshalFailure)
+			panic(err)
+		}
+		var buffer bytes.Buffer
+		json.Indent(&buffer, serialized, "", "  ")
+		scopes = append(scopes, buffer.String())
+	}
+	self.out.Print(fmt.Sprintf("%s\n%s,\n%s\n", OpenJson, strings.Join(scopes, ","), CloseJson))
+}
+func (self *JsonReporter) reset() {
+	self.scopes = []*ScopeResult{}
+	self.index = map[string]*ScopeResult{}
+	self.currentKey = nil
+}
+
+func (self *JsonReporter) Write(content []byte) (written int, err error) {
+	self.current.Output += string(content)
+	return len(content), nil
+}
+
+func NewJsonReporter(out *Printer) *JsonReporter {
+	self := new(JsonReporter)
+	self.out = out
+	self.reset()
+	return self
+}
+
+const OpenJson = ">->->OPEN-JSON->->->"   // "⌦"
+const CloseJson = "<-<-<-CLOSE-JSON<-<-<" // "⌫"
+const jsonMarshalFailure = `
+
+GOCONVEY_JSON_MARSHALL_FAILURE: There was an error when attempting to convert test results to JSON.
+Please file a bug report and reference the code that caused this failure if possible.
+
+Here's the panic:
+
+`

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/printer.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/printer.go
@@ -1,0 +1,57 @@
+package reporting
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type Printer struct {
+	out    io.Writer
+	prefix string
+}
+
+func (self *Printer) Println(message string, values ...interface{}) {
+	formatted := self.format(message, values...) + newline
+	self.out.Write([]byte(formatted))
+}
+
+func (self *Printer) Print(message string, values ...interface{}) {
+	formatted := self.format(message, values...)
+	self.out.Write([]byte(formatted))
+}
+
+func (self *Printer) Insert(text string) {
+	self.out.Write([]byte(text))
+}
+
+func (self *Printer) format(message string, values ...interface{}) string {
+	var formatted string
+	if len(values) == 0 {
+		formatted = self.prefix + message
+	} else {
+		formatted = self.prefix + fmt.Sprintf(message, values...)
+	}
+	indented := strings.Replace(formatted, newline, newline+self.prefix, -1)
+	return strings.TrimRight(indented, space)
+}
+
+func (self *Printer) Indent() {
+	self.prefix += pad
+}
+
+func (self *Printer) Dedent() {
+	if len(self.prefix) >= padLength {
+		self.prefix = self.prefix[:len(self.prefix)-padLength]
+	}
+}
+
+func NewPrinter(out io.Writer) *Printer {
+	self := new(Printer)
+	self.out = out
+	return self
+}
+
+const space = " "
+const pad = space + space
+const padLength = len(pad)

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/printer_test.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/printer_test.go
@@ -1,0 +1,181 @@
+package reporting
+
+import "testing"
+
+func TestPrint(t *testing.T) {
+	file := newMemoryFile()
+	printer := NewPrinter(file)
+	const expected = "Hello, World!"
+
+	printer.Print(expected)
+
+	if file.buffer != expected {
+		t.Errorf("Expected '%s' to equal '%s'.", expected, file.buffer)
+	}
+}
+
+func TestPrintFormat(t *testing.T) {
+	file := newMemoryFile()
+	printer := NewPrinter(file)
+	template := "Hi, %s"
+	name := "Ralph"
+	expected := "Hi, Ralph"
+
+	printer.Print(template, name)
+
+	if file.buffer != expected {
+		t.Errorf("Expected '%s' to equal '%s'.", expected, file.buffer)
+	}
+}
+
+func TestPrintPreservesEncodedStrings(t *testing.T) {
+	file := newMemoryFile()
+	printer := NewPrinter(file)
+	const expected = "= -> %3D"
+	printer.Print(expected)
+
+	if file.buffer != expected {
+		t.Errorf("Expected '%s' to equal '%s'.", expected, file.buffer)
+	}
+}
+
+func TestPrintln(t *testing.T) {
+	file := newMemoryFile()
+	printer := NewPrinter(file)
+	const expected = "Hello, World!"
+
+	printer.Println(expected)
+
+	if file.buffer != expected+"\n" {
+		t.Errorf("Expected '%s' to equal '%s'.", expected, file.buffer)
+	}
+}
+
+func TestPrintlnFormat(t *testing.T) {
+	file := newMemoryFile()
+	printer := NewPrinter(file)
+	template := "Hi, %s"
+	name := "Ralph"
+	expected := "Hi, Ralph\n"
+
+	printer.Println(template, name)
+
+	if file.buffer != expected {
+		t.Errorf("Expected '%s' to equal '%s'.", expected, file.buffer)
+	}
+}
+
+func TestPrintlnPreservesEncodedStrings(t *testing.T) {
+	file := newMemoryFile()
+	printer := NewPrinter(file)
+	const expected = "= -> %3D"
+	printer.Println(expected)
+
+	if file.buffer != expected+"\n" {
+		t.Errorf("Expected '%s' to equal '%s'.", expected, file.buffer)
+	}
+}
+
+func TestPrintIndented(t *testing.T) {
+	file := newMemoryFile()
+	printer := NewPrinter(file)
+	const message = "Hello, World!\nGoodbye, World!"
+	const expected = "  Hello, World!\n  Goodbye, World!"
+
+	printer.Indent()
+	printer.Print(message)
+
+	if file.buffer != expected {
+		t.Errorf("Expected '%s' to equal '%s'.", expected, file.buffer)
+	}
+}
+
+func TestPrintDedented(t *testing.T) {
+	file := newMemoryFile()
+	printer := NewPrinter(file)
+	const expected = "Hello, World!\nGoodbye, World!"
+
+	printer.Indent()
+	printer.Dedent()
+	printer.Print(expected)
+
+	if file.buffer != expected {
+		t.Errorf("Expected '%s' to equal '%s'.", expected, file.buffer)
+	}
+}
+
+func TestPrintlnIndented(t *testing.T) {
+	file := newMemoryFile()
+	printer := NewPrinter(file)
+	const message = "Hello, World!\nGoodbye, World!"
+	const expected = "  Hello, World!\n  Goodbye, World!\n"
+
+	printer.Indent()
+	printer.Println(message)
+
+	if file.buffer != expected {
+		t.Errorf("Expected '%s' to equal '%s'.", expected, file.buffer)
+	}
+}
+
+func TestPrintlnDedented(t *testing.T) {
+	file := newMemoryFile()
+	printer := NewPrinter(file)
+	const expected = "Hello, World!\nGoodbye, World!"
+
+	printer.Indent()
+	printer.Dedent()
+	printer.Println(expected)
+
+	if file.buffer != expected+"\n" {
+		t.Errorf("Expected '%s' to equal '%s'.", expected, file.buffer)
+	}
+}
+
+func TestDedentTooFarShouldNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Error("Should not have panicked!")
+		}
+	}()
+	file := newMemoryFile()
+	printer := NewPrinter(file)
+
+	printer.Dedent()
+
+	t.Log("Getting to this point without panicking means we passed.")
+}
+
+func TestInsert(t *testing.T) {
+	file := newMemoryFile()
+	printer := NewPrinter(file)
+
+	printer.Indent()
+	printer.Print("Hi")
+	printer.Insert(" there")
+	printer.Dedent()
+
+	expected := "  Hi there"
+	if file.buffer != expected {
+		t.Errorf("Should have written '%s' but instead wrote '%s'.", expected, file.buffer)
+	}
+}
+
+////////////////// memoryFile ////////////////////
+
+type memoryFile struct {
+	buffer string
+}
+
+func (self *memoryFile) Write(p []byte) (n int, err error) {
+	self.buffer += string(p)
+	return len(p), nil
+}
+
+func (self *memoryFile) String() string {
+	return self.buffer
+}
+
+func newMemoryFile() *memoryFile {
+	return new(memoryFile)
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/problems.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/problems.go
@@ -1,0 +1,80 @@
+package reporting
+
+import "fmt"
+
+type problem struct {
+	silent   bool
+	out      *Printer
+	errors   []*AssertionResult
+	failures []*AssertionResult
+}
+
+func (self *problem) BeginStory(story *StoryReport) {}
+
+func (self *problem) Enter(scope *ScopeReport) {}
+
+func (self *problem) Report(report *AssertionResult) {
+	if report.Error != nil {
+		self.errors = append(self.errors, report)
+	} else if report.Failure != "" {
+		self.failures = append(self.failures, report)
+	}
+}
+
+func (self *problem) Exit() {}
+
+func (self *problem) EndStory() {
+	self.show(self.showErrors, redColor)
+	self.show(self.showFailures, yellowColor)
+	self.prepareForNextStory()
+}
+func (self *problem) show(display func(), color string) {
+	if !self.silent {
+		fmt.Print(color)
+	}
+	display()
+	if !self.silent {
+		fmt.Print(resetColor)
+	}
+	self.out.Dedent()
+}
+func (self *problem) showErrors() {
+	for i, e := range self.errors {
+		if i == 0 {
+			self.out.Println("\nErrors:\n")
+			self.out.Indent()
+		}
+		self.out.Println(errorTemplate, e.File, e.Line, e.Error, e.StackTrace)
+	}
+}
+func (self *problem) showFailures() {
+	for i, f := range self.failures {
+		if i == 0 {
+			self.out.Println("\nFailures:\n")
+			self.out.Indent()
+		}
+		self.out.Println(failureTemplate, f.File, f.Line, f.Failure)
+	}
+}
+
+func (self *problem) Write(content []byte) (written int, err error) {
+	return len(content), nil // no-op
+}
+
+func NewProblemReporter(out *Printer) *problem {
+	self := new(problem)
+	self.out = out
+	self.prepareForNextStory()
+	return self
+}
+
+func NewSilentProblemReporter(out *Printer) *problem {
+	self := NewProblemReporter(out)
+	self.silent = true
+	return self
+}
+
+func (self *problem) prepareForNextStory() {
+	self.errors = []*AssertionResult{}
+	self.failures = []*AssertionResult{}
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/problems_test.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/problems_test.go
@@ -1,0 +1,51 @@
+package reporting
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNoopProblemReporterActions(t *testing.T) {
+	file, reporter := setup()
+	reporter.BeginStory(nil)
+	reporter.Enter(nil)
+	reporter.Exit()
+	expected := ""
+	actual := file.String()
+	if expected != actual {
+		t.Errorf("Expected: '(blank)'\nActual:  '%s'", actual)
+	}
+}
+
+func TestReporterPrintsFailuresAndErrorsAtTheEndOfTheStory(t *testing.T) {
+	file, reporter := setup()
+	reporter.Report(NewFailureReport("failed"))
+	reporter.Report(NewErrorReport("error"))
+	reporter.Report(NewSuccessReport())
+	reporter.EndStory()
+
+	result := file.String()
+	if !strings.Contains(result, "Errors:\n") {
+		t.Errorf("Expected errors, found none.")
+	}
+	if !strings.Contains(result, "Failures:\n") {
+		t.Errorf("Expected failures, found none.")
+	}
+
+	// Each stack trace looks like: `* /path/to/file.go`, so look for `* `.
+	// With go 1.4+ there is a line in some stack traces that looks like this:
+	//   `testing.(*M).Run(0x2082d60a0, 0x25b7c0)`
+	// So we can't just look for "*" anymore.
+	problemCount := strings.Count(result, "* ")
+	if problemCount != 2 {
+		t.Errorf("Expected one failure and one error (total of 2 '*' characters). Got %d", problemCount)
+	}
+}
+
+func setup() (file *memoryFile, reporter *problem) {
+	monochrome()
+	file = newMemoryFile()
+	printer := NewPrinter(file)
+	reporter = NewProblemReporter(printer)
+	return
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/reporter.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/reporter.go
@@ -1,0 +1,39 @@
+package reporting
+
+import "io"
+
+type Reporter interface {
+	BeginStory(story *StoryReport)
+	Enter(scope *ScopeReport)
+	Report(r *AssertionResult)
+	Exit()
+	EndStory()
+	io.Writer
+}
+
+type reporters struct{ collection []Reporter }
+
+func (self *reporters) BeginStory(s *StoryReport) { self.foreach(func(r Reporter) { r.BeginStory(s) }) }
+func (self *reporters) Enter(s *ScopeReport)      { self.foreach(func(r Reporter) { r.Enter(s) }) }
+func (self *reporters) Report(a *AssertionResult) { self.foreach(func(r Reporter) { r.Report(a) }) }
+func (self *reporters) Exit()                     { self.foreach(func(r Reporter) { r.Exit() }) }
+func (self *reporters) EndStory()                 { self.foreach(func(r Reporter) { r.EndStory() }) }
+
+func (self *reporters) Write(contents []byte) (written int, err error) {
+	self.foreach(func(r Reporter) {
+		written, err = r.Write(contents)
+	})
+	return written, err
+}
+
+func (self *reporters) foreach(action func(Reporter)) {
+	for _, r := range self.collection {
+		action(r)
+	}
+}
+
+func NewReporters(collection ...Reporter) *reporters {
+	self := new(reporters)
+	self.collection = collection
+	return self
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/reporter_test.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/reporter_test.go
@@ -1,0 +1,94 @@
+package reporting
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestEachNestedReporterReceivesTheCallFromTheContainingReporter(t *testing.T) {
+	fake1 := newFakeReporter()
+	fake2 := newFakeReporter()
+	reporter := NewReporters(fake1, fake2)
+
+	reporter.BeginStory(nil)
+	assertTrue(t, fake1.begun)
+	assertTrue(t, fake2.begun)
+
+	reporter.Enter(NewScopeReport("scope"))
+	assertTrue(t, fake1.entered)
+	assertTrue(t, fake2.entered)
+
+	reporter.Report(NewSuccessReport())
+	assertTrue(t, fake1.reported)
+	assertTrue(t, fake2.reported)
+
+	reporter.Exit()
+	assertTrue(t, fake1.exited)
+	assertTrue(t, fake2.exited)
+
+	reporter.EndStory()
+	assertTrue(t, fake1.ended)
+	assertTrue(t, fake2.ended)
+
+	content := []byte("hi")
+	written, err := reporter.Write(content)
+	assertTrue(t, fake1.written)
+	assertTrue(t, fake2.written)
+	assertEqual(t, written, len(content))
+	assertNil(t, err)
+
+}
+
+func assertTrue(t *testing.T, value bool) {
+	if !value {
+		_, _, line, _ := runtime.Caller(1)
+		t.Errorf("Value should have been true (but was false). See line %d", line)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual int) {
+	if actual != expected {
+		_, _, line, _ := runtime.Caller(1)
+		t.Errorf("Value should have been %d (but was %d). See line %d", expected, actual, line)
+	}
+}
+
+func assertNil(t *testing.T, err error) {
+	if err != nil {
+		_, _, line, _ := runtime.Caller(1)
+		t.Errorf("Error should have been <nil> (but wasn't). See line %d", err, line)
+	}
+}
+
+type fakeReporter struct {
+	begun    bool
+	entered  bool
+	reported bool
+	exited   bool
+	ended    bool
+	written  bool
+}
+
+func newFakeReporter() *fakeReporter {
+	return &fakeReporter{}
+}
+
+func (self *fakeReporter) BeginStory(story *StoryReport) {
+	self.begun = true
+}
+func (self *fakeReporter) Enter(scope *ScopeReport) {
+	self.entered = true
+}
+func (self *fakeReporter) Report(report *AssertionResult) {
+	self.reported = true
+}
+func (self *fakeReporter) Exit() {
+	self.exited = true
+}
+func (self *fakeReporter) EndStory() {
+	self.ended = true
+}
+func (self *fakeReporter) Write(content []byte) (int, error) {
+	self.written = true
+	return len(content), nil
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/reporting.goconvey
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/reporting.goconvey
@@ -1,0 +1,2 @@
+#ignore
+-timeout=1s

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/reports.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/reports.go
@@ -1,0 +1,179 @@
+package reporting
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/smartystreets/goconvey/convey/gotest"
+)
+
+////////////////// ScopeReport ////////////////////
+
+type ScopeReport struct {
+	Title string
+	File  string
+	Line  int
+}
+
+func NewScopeReport(title string) *ScopeReport {
+	file, line, _ := gotest.ResolveExternalCaller()
+	self := new(ScopeReport)
+	self.Title = title
+	self.File = file
+	self.Line = line
+	return self
+}
+
+////////////////// ScopeResult ////////////////////
+
+type ScopeResult struct {
+	Title      string
+	File       string
+	Line       int
+	Depth      int
+	Assertions []*AssertionResult
+	Output     string
+}
+
+func newScopeResult(title string, depth int, file string, line int) *ScopeResult {
+	self := new(ScopeResult)
+	self.Title = title
+	self.Depth = depth
+	self.File = file
+	self.Line = line
+	self.Assertions = []*AssertionResult{}
+	return self
+}
+
+/////////////////// StoryReport /////////////////////
+
+type StoryReport struct {
+	Test T
+	Name string
+	File string
+	Line int
+}
+
+func NewStoryReport(test T) *StoryReport {
+	file, line, name := gotest.ResolveExternalCaller()
+	name = removePackagePath(name)
+	self := new(StoryReport)
+	self.Test = test
+	self.Name = name
+	self.File = file
+	self.Line = line
+	return self
+}
+
+// name comes in looking like "github.com/smartystreets/goconvey/examples.TestName".
+// We only want the stuff after the last '.', which is the name of the test function.
+func removePackagePath(name string) string {
+	parts := strings.Split(name, ".")
+	return parts[len(parts)-1]
+}
+
+/////////////////// FailureView ////////////////////////
+
+// This struct is also declared in github.com/smartystreets/assertions.
+// The json struct tags should be equal in both declarations.
+type FailureView struct {
+	Message  string `json:"Message"`
+	Expected string `json:"Expected"`
+	Actual   string `json:"Actual"`
+}
+
+////////////////////AssertionResult //////////////////////
+
+type AssertionResult struct {
+	File       string
+	Line       int
+	Expected   string
+	Actual     string
+	Failure    string
+	Error      interface{}
+	StackTrace string
+	Skipped    bool
+}
+
+func NewFailureReport(failure string) *AssertionResult {
+	report := new(AssertionResult)
+	report.File, report.Line = caller()
+	report.StackTrace = stackTrace()
+	parseFailure(failure, report)
+	return report
+}
+func parseFailure(failure string, report *AssertionResult) {
+	view := new(FailureView)
+	err := json.Unmarshal([]byte(failure), view)
+	if err == nil {
+		report.Failure = view.Message
+		report.Expected = view.Expected
+		report.Actual = view.Actual
+	} else {
+		report.Failure = failure
+	}
+}
+func NewErrorReport(err interface{}) *AssertionResult {
+	report := new(AssertionResult)
+	report.File, report.Line = caller()
+	report.StackTrace = fullStackTrace()
+	report.Error = fmt.Sprintf("%v", err)
+	return report
+}
+func NewSuccessReport() *AssertionResult {
+	return new(AssertionResult)
+}
+func NewSkipReport() *AssertionResult {
+	report := new(AssertionResult)
+	report.File, report.Line = caller()
+	report.StackTrace = fullStackTrace()
+	report.Skipped = true
+	return report
+}
+
+func caller() (file string, line int) {
+	file, line, _ = gotest.ResolveExternalCaller()
+	return
+}
+
+func stackTrace() string {
+	buffer := make([]byte, 1024*64)
+	n := runtime.Stack(buffer, false)
+	return removeInternalEntries(string(buffer[:n]))
+}
+func fullStackTrace() string {
+	buffer := make([]byte, 1024*64)
+	n := runtime.Stack(buffer, true)
+	return removeInternalEntries(string(buffer[:n]))
+}
+func removeInternalEntries(stack string) string {
+	lines := strings.Split(stack, newline)
+	filtered := []string{}
+	for _, line := range lines {
+		if !isExternal(line) {
+			filtered = append(filtered, line)
+		}
+	}
+	return strings.Join(filtered, newline)
+}
+func isExternal(line string) bool {
+	for _, p := range internalPackages {
+		if strings.Contains(line, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// NOTE: any new packages that host goconvey packages will need to be added here!
+// An alternative is to scan the goconvey directory and then exclude stuff like
+// the examples package but that's nasty too.
+var internalPackages = []string{
+	"goconvey/assertions",
+	"goconvey/convey",
+	"goconvey/execution",
+	"goconvey/gotest",
+	"goconvey/reporting",
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/statistics.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/statistics.go
@@ -1,0 +1,108 @@
+package reporting
+
+import (
+	"fmt"
+	"sync"
+)
+
+func (self *statistics) BeginStory(story *StoryReport) {}
+
+func (self *statistics) Enter(scope *ScopeReport) {}
+
+func (self *statistics) Report(report *AssertionResult) {
+	self.Lock()
+	defer self.Unlock()
+
+	if !self.failing && report.Failure != "" {
+		self.failing = true
+	}
+	if !self.erroring && report.Error != nil {
+		self.erroring = true
+	}
+	if report.Skipped {
+		self.skipped += 1
+	} else {
+		self.total++
+	}
+}
+
+func (self *statistics) Exit() {}
+
+func (self *statistics) EndStory() {
+	self.Lock()
+	defer self.Unlock()
+
+	if !self.suppressed {
+		self.printSummaryLocked()
+	}
+}
+
+func (self *statistics) Suppress() {
+	self.Lock()
+	defer self.Unlock()
+	self.suppressed = true
+}
+
+func (self *statistics) PrintSummary() {
+	self.Lock()
+	defer self.Unlock()
+	self.printSummaryLocked()
+}
+
+func (self *statistics) printSummaryLocked() {
+	self.reportAssertionsLocked()
+	self.reportSkippedSectionsLocked()
+	self.completeReportLocked()
+}
+func (self *statistics) reportAssertionsLocked() {
+	self.decideColorLocked()
+	self.out.Print("\n%d total %s", self.total, plural("assertion", self.total))
+}
+func (self *statistics) decideColorLocked() {
+	if self.failing && !self.erroring {
+		fmt.Print(yellowColor)
+	} else if self.erroring {
+		fmt.Print(redColor)
+	} else {
+		fmt.Print(greenColor)
+	}
+}
+func (self *statistics) reportSkippedSectionsLocked() {
+	if self.skipped > 0 {
+		fmt.Print(yellowColor)
+		self.out.Print(" (one or more sections skipped)")
+	}
+}
+func (self *statistics) completeReportLocked() {
+	fmt.Print(resetColor)
+	self.out.Print("\n")
+	self.out.Print("\n")
+}
+
+func (self *statistics) Write(content []byte) (written int, err error) {
+	return len(content), nil // no-op
+}
+
+func NewStatisticsReporter(out *Printer) *statistics {
+	self := statistics{}
+	self.out = out
+	return &self
+}
+
+type statistics struct {
+	sync.Mutex
+
+	out        *Printer
+	total      int
+	failing    bool
+	erroring   bool
+	skipped    int
+	suppressed bool
+}
+
+func plural(word string, count int) string {
+	if count == 1 {
+		return word
+	}
+	return word + "s"
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/story.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/story.go
@@ -1,0 +1,73 @@
+// TODO: in order for this reporter to be completely honest
+// we need to retrofit to be more like the json reporter such that:
+// 1. it maintains ScopeResult collections, which count assertions
+// 2. it reports only after EndStory(), so that all tick marks
+//    are placed near the appropriate title.
+// 3. Under unit test
+
+package reporting
+
+import (
+	"fmt"
+	"strings"
+)
+
+type story struct {
+	out        *Printer
+	titlesById map[string]string
+	currentKey []string
+}
+
+func (self *story) BeginStory(story *StoryReport) {}
+
+func (self *story) Enter(scope *ScopeReport) {
+	self.out.Indent()
+
+	self.currentKey = append(self.currentKey, scope.Title)
+	ID := strings.Join(self.currentKey, "|")
+
+	if _, found := self.titlesById[ID]; !found {
+		self.out.Println("")
+		self.out.Print(scope.Title)
+		self.out.Insert(" ")
+		self.titlesById[ID] = scope.Title
+	}
+}
+
+func (self *story) Report(report *AssertionResult) {
+	if report.Error != nil {
+		fmt.Print(redColor)
+		self.out.Insert(error_)
+	} else if report.Failure != "" {
+		fmt.Print(yellowColor)
+		self.out.Insert(failure)
+	} else if report.Skipped {
+		fmt.Print(yellowColor)
+		self.out.Insert(skip)
+	} else {
+		fmt.Print(greenColor)
+		self.out.Insert(success)
+	}
+	fmt.Print(resetColor)
+}
+
+func (self *story) Exit() {
+	self.out.Dedent()
+	self.currentKey = self.currentKey[:len(self.currentKey)-1]
+}
+
+func (self *story) EndStory() {
+	self.titlesById = make(map[string]string)
+	self.out.Println("\n")
+}
+
+func (self *story) Write(content []byte) (written int, err error) {
+	return len(content), nil // no-op
+}
+
+func NewStoryReporter(out *Printer) *story {
+	self := new(story)
+	self.out = out
+	self.titlesById = make(map[string]string)
+	return self
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting_hooks_test.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting_hooks_test.go
@@ -1,0 +1,317 @@
+package convey
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey/reporting"
+)
+
+func TestSingleScopeReported(t *testing.T) {
+	myReporter, test := setupFakeReporter()
+
+	Convey("A", test, func() {
+		So(1, ShouldEqual, 1)
+	})
+
+	expectEqual(t, "Begin|A|Success|Exit|End", myReporter.wholeStory())
+}
+
+func TestNestedScopeReported(t *testing.T) {
+	myReporter, test := setupFakeReporter()
+
+	Convey("A", test, func() {
+		Convey("B", func() {
+			So(1, ShouldEqual, 1)
+		})
+	})
+
+	expectEqual(t, "Begin|A|B|Success|Exit|Exit|End", myReporter.wholeStory())
+}
+
+func TestFailureReported(t *testing.T) {
+	myReporter, test := setupFakeReporter()
+
+	Convey("A", test, func() {
+		So(1, ShouldBeNil)
+	})
+
+	expectEqual(t, "Begin|A|Failure|Exit|End", myReporter.wholeStory())
+}
+
+func TestFirstFailureEndsScopeExecution(t *testing.T) {
+	myReporter, test := setupFakeReporter()
+
+	Convey("A", test, func() {
+		So(1, ShouldBeNil)
+		So(nil, ShouldBeNil)
+	})
+
+	expectEqual(t, "Begin|A|Failure|Exit|End", myReporter.wholeStory())
+}
+
+func TestComparisonFailureDeserializedAndReported(t *testing.T) {
+	myReporter, test := setupFakeReporter()
+
+	Convey("A", test, func() {
+		So("hi", ShouldEqual, "bye")
+	})
+
+	expectEqual(t, "Begin|A|Failure(bye/hi)|Exit|End", myReporter.wholeStory())
+}
+
+func TestNestedFailureReported(t *testing.T) {
+	myReporter, test := setupFakeReporter()
+
+	Convey("A", test, func() {
+		Convey("B", func() {
+			So(2, ShouldBeNil)
+		})
+	})
+
+	expectEqual(t, "Begin|A|B|Failure|Exit|Exit|End", myReporter.wholeStory())
+}
+
+func TestSuccessAndFailureReported(t *testing.T) {
+	myReporter, test := setupFakeReporter()
+
+	Convey("A", test, func() {
+		So(nil, ShouldBeNil)
+		So(1, ShouldBeNil)
+	})
+
+	expectEqual(t, "Begin|A|Success|Failure|Exit|End", myReporter.wholeStory())
+}
+
+func TestIncompleteActionReportedAsSkipped(t *testing.T) {
+	myReporter, test := setupFakeReporter()
+
+	Convey("A", test, func() {
+		Convey("B", nil)
+	})
+
+	expectEqual(t, "Begin|A|B|Skipped|Exit|Exit|End", myReporter.wholeStory())
+}
+
+func TestSkippedConveyReportedAsSkipped(t *testing.T) {
+	myReporter, test := setupFakeReporter()
+
+	Convey("A", test, func() {
+		SkipConvey("B", func() {
+			So(1, ShouldEqual, 1)
+		})
+	})
+
+	expectEqual(t, "Begin|A|B|Skipped|Exit|Exit|End", myReporter.wholeStory())
+}
+
+func TestMultipleSkipsAreReported(t *testing.T) {
+	myReporter, test := setupFakeReporter()
+
+	Convey("A", test, func() {
+		Convey("0", func() {
+			So(nil, ShouldBeNil)
+		})
+
+		SkipConvey("1", func() {})
+		SkipConvey("2", func() {})
+
+		Convey("3", nil)
+		Convey("4", nil)
+
+		Convey("5", func() {
+			So(nil, ShouldBeNil)
+		})
+	})
+
+	expected := "Begin" +
+		"|A|0|Success|Exit|Exit" +
+		"|A|1|Skipped|Exit|Exit" +
+		"|A|2|Skipped|Exit|Exit" +
+		"|A|3|Skipped|Exit|Exit" +
+		"|A|4|Skipped|Exit|Exit" +
+		"|A|5|Success|Exit|Exit" +
+		"|End"
+
+	expectEqual(t, expected, myReporter.wholeStory())
+}
+
+func TestSkippedAssertionIsNotReported(t *testing.T) {
+	myReporter, test := setupFakeReporter()
+
+	Convey("A", test, func() {
+		SkipSo(1, ShouldEqual, 1)
+	})
+
+	expectEqual(t, "Begin|A|Skipped|Exit|End", myReporter.wholeStory())
+}
+
+func TestMultipleSkippedAssertionsAreNotReported(t *testing.T) {
+	myReporter, test := setupFakeReporter()
+
+	Convey("A", test, func() {
+		SkipSo(1, ShouldEqual, 1)
+		So(1, ShouldEqual, 1)
+		SkipSo(1, ShouldEqual, 1)
+	})
+
+	expectEqual(t, "Begin|A|Skipped|Success|Skipped|Exit|End", myReporter.wholeStory())
+}
+
+func TestErrorByManualPanicReported(t *testing.T) {
+	myReporter, test := setupFakeReporter()
+
+	Convey("A", test, func() {
+		panic("Gopher alert!")
+	})
+
+	expectEqual(t, "Begin|A|Error|Exit|End", myReporter.wholeStory())
+}
+
+func TestIterativeConveysReported(t *testing.T) {
+	myReporter, test := setupFakeReporter()
+
+	Convey("A", test, func() {
+		for x := 0; x < 3; x++ {
+			Convey(strconv.Itoa(x), func() {
+				So(x, ShouldEqual, x)
+			})
+		}
+	})
+
+	expectEqual(t, "Begin|A|0|Success|Exit|Exit|A|1|Success|Exit|Exit|A|2|Success|Exit|Exit|End", myReporter.wholeStory())
+}
+
+func TestNestedIterativeConveysReported(t *testing.T) {
+	myReporter, test := setupFakeReporter()
+
+	Convey("A", test, func() {
+		for x := 0; x < 3; x++ {
+			Convey(strconv.Itoa(x), func() {
+				for y := 0; y < 3; y++ {
+					Convey("< "+strconv.Itoa(y), func() {
+						So(x, ShouldBeLessThan, y)
+					})
+				}
+			})
+		}
+	})
+
+	expectEqual(t, ("Begin|" +
+		"A|0|< 0|Failure|Exit|Exit|Exit|" +
+		"A|0|< 1|Success|Exit|Exit|Exit|" +
+		"A|0|< 2|Success|Exit|Exit|Exit|" +
+		"A|1|< 0|Failure|Exit|Exit|Exit|" +
+		"A|1|< 1|Failure|Exit|Exit|Exit|" +
+		"A|1|< 2|Success|Exit|Exit|Exit|" +
+		"A|2|< 0|Failure|Exit|Exit|Exit|" +
+		"A|2|< 1|Failure|Exit|Exit|Exit|" +
+		"A|2|< 2|Failure|Exit|Exit|Exit|" +
+		"End"), myReporter.wholeStory())
+}
+
+func TestEmbeddedAssertionReported(t *testing.T) {
+	myReporter, test := setupFakeReporter()
+
+	Convey("A", test, func(c C) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			c.So(r.FormValue("msg"), ShouldEqual, "ping")
+		}))
+		http.DefaultClient.Get(ts.URL + "?msg=ping")
+	})
+
+	expectEqual(t, "Begin|A|Success|Exit|End", myReporter.wholeStory())
+}
+
+func TestEmbeddedContextHelperReported(t *testing.T) {
+	myReporter, test := setupFakeReporter()
+
+	helper := func(c C) http.HandlerFunc {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			c.Convey("Embedded", func() {
+				So(r.FormValue("msg"), ShouldEqual, "ping")
+			})
+		})
+	}
+
+	Convey("A", test, func(c C) {
+		ts := httptest.NewServer(helper(c))
+		http.DefaultClient.Get(ts.URL + "?msg=ping")
+	})
+
+	expectEqual(t, "Begin|A|Embedded|Success|Exit|Exit|End", myReporter.wholeStory())
+}
+
+func expectEqual(t *testing.T, expected interface{}, actual interface{}) {
+	if expected != actual {
+		_, file, line, _ := runtime.Caller(1)
+		t.Errorf("Expected '%v' to be '%v' but it wasn't. See '%s' at line %d.",
+			actual, expected, path.Base(file), line)
+	}
+}
+
+func setupFakeReporter() (*fakeReporter, *fakeGoTest) {
+	myReporter := new(fakeReporter)
+	myReporter.calls = []string{}
+	testReporter = myReporter
+	return myReporter, new(fakeGoTest)
+}
+
+type fakeReporter struct {
+	calls []string
+}
+
+func (self *fakeReporter) BeginStory(story *reporting.StoryReport) {
+	self.calls = append(self.calls, "Begin")
+}
+
+func (self *fakeReporter) Enter(scope *reporting.ScopeReport) {
+	self.calls = append(self.calls, scope.Title)
+}
+
+func (self *fakeReporter) Report(report *reporting.AssertionResult) {
+	if report.Error != nil {
+		self.calls = append(self.calls, "Error")
+	} else if report.Failure != "" {
+		message := "Failure"
+		if report.Expected != "" || report.Actual != "" {
+			message += fmt.Sprintf("(%s/%s)", report.Expected, report.Actual)
+		}
+		self.calls = append(self.calls, message)
+	} else if report.Skipped {
+		self.calls = append(self.calls, "Skipped")
+	} else {
+		self.calls = append(self.calls, "Success")
+	}
+}
+
+func (self *fakeReporter) Exit() {
+	self.calls = append(self.calls, "Exit")
+}
+
+func (self *fakeReporter) EndStory() {
+	self.calls = append(self.calls, "End")
+}
+
+func (self *fakeReporter) Write(content []byte) (int, error) {
+	return len(content), nil // no-op
+}
+
+func (self *fakeReporter) wholeStory() string {
+	return strings.Join(self.calls, "|")
+}
+
+////////////////////////////////
+
+type fakeGoTest struct{}
+
+func (self *fakeGoTest) Fail()                                     {}
+func (self *fakeGoTest) Fatalf(format string, args ...interface{}) {}
+
+var test t = new(fakeGoTest)

--- a/vendor/github.com/smartystreets/goconvey/convey/story_conventions_test.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/story_conventions_test.go
@@ -1,0 +1,175 @@
+package convey
+
+import (
+	"reflect"
+	"testing"
+)
+
+func expectPanic(t *testing.T, f string) interface{} {
+	r := recover()
+	if r != nil {
+		if cp, ok := r.(*conveyErr); ok {
+			if cp.fmt != f {
+				t.Error("Incorrect panic message.")
+			}
+		} else {
+			t.Errorf("Incorrect panic type. %s", reflect.TypeOf(r))
+		}
+	} else {
+		t.Error("Expected panic but none occured")
+	}
+	return r
+}
+
+func TestMissingTopLevelGoTestReferenceCausesPanic(t *testing.T) {
+	output := map[string]bool{}
+
+	defer expectEqual(t, false, output["good"])
+	defer expectPanic(t, missingGoTest)
+
+	Convey("Hi", func() {
+		output["bad"] = true // this shouldn't happen
+	})
+}
+
+func TestMissingTopLevelGoTestReferenceAfterGoodExample(t *testing.T) {
+	output := map[string]bool{}
+
+	defer func() {
+		expectEqual(t, true, output["good"])
+		expectEqual(t, false, output["bad"])
+	}()
+	defer expectPanic(t, missingGoTest)
+
+	Convey("Good example", t, func() {
+		output["good"] = true
+	})
+
+	Convey("Bad example", func() {
+		output["bad"] = true // shouldn't happen
+	})
+}
+
+func TestExtraReferencePanics(t *testing.T) {
+	output := map[string]bool{}
+
+	defer expectEqual(t, false, output["bad"])
+	defer expectPanic(t, extraGoTest)
+
+	Convey("Good example", t, func() {
+		Convey("Bad example - passing in *testing.T a second time!", t, func() {
+			output["bad"] = true // shouldn't happen
+		})
+	})
+}
+
+func TestParseRegistrationMissingRequiredElements(t *testing.T) {
+	defer expectPanic(t, parseError)
+
+	Convey()
+}
+
+func TestParseRegistration_MissingNameString(t *testing.T) {
+	defer expectPanic(t, parseError)
+
+	Convey(func() {})
+}
+
+func TestParseRegistration_MissingActionFunc(t *testing.T) {
+	defer expectPanic(t, parseError)
+
+	Convey("Hi there", 12345)
+}
+
+func TestFailureModeNoContext(t *testing.T) {
+	Convey("Foo", t, func() {
+		done := make(chan int, 1)
+		go func() {
+			defer func() { done <- 1 }()
+			defer expectPanic(t, noStackContext)
+			So(len("I have no context"), ShouldBeGreaterThan, 0)
+		}()
+		<-done
+	})
+}
+
+func TestFailureModeDuplicateSuite(t *testing.T) {
+	Convey("cool", t, func() {
+		defer expectPanic(t, multipleIdenticalConvey)
+
+		Convey("dup", nil)
+		Convey("dup", nil)
+	})
+}
+
+func TestFailureModeIndeterminentSuiteNames(t *testing.T) {
+	defer expectPanic(t, differentConveySituations)
+
+	name := "bob"
+	Convey("cool", t, func() {
+		for i := 0; i < 3; i++ {
+			Convey(name, func() {})
+			name += "bob"
+		}
+	})
+}
+
+func TestFailureModeNestedIndeterminentSuiteNames(t *testing.T) {
+	defer expectPanic(t, differentConveySituations)
+
+	name := "bob"
+	Convey("cool", t, func() {
+		Convey("inner", func() {
+			for i := 0; i < 3; i++ {
+				Convey(name, func() {})
+				name += "bob"
+			}
+		})
+	})
+}
+
+func TestFailureModeParameterButMissing(t *testing.T) {
+	defer expectPanic(t, parseError)
+
+	prepare()
+
+	Convey("Foobar", t, FailureHalts)
+}
+
+func TestFailureModeParameterWithAction(t *testing.T) {
+	prepare()
+
+	Convey("Foobar", t, FailureHalts, func() {})
+}
+
+func TestExtraConveyParameters(t *testing.T) {
+	defer expectPanic(t, parseError)
+
+	prepare()
+
+	Convey("Foobar", t, FailureHalts, func() {}, "This is not supposed to be here")
+}
+
+func TestExtraConveyParameters2(t *testing.T) {
+	defer expectPanic(t, parseError)
+
+	prepare()
+
+	Convey("Foobar", t, func() {}, "This is not supposed to be here")
+}
+
+func TestExtraConveyParameters3(t *testing.T) {
+	defer expectPanic(t, parseError)
+
+	output := prepare()
+
+	Convey("A", t, func() {
+		output += "A "
+
+		Convey("B", func() {
+			output += "B "
+		}, "This is not supposed to be here")
+	})
+
+	expectEqual(t, "A ", output)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -259,8 +259,14 @@
 			"checksumSHA1": "GCCxJvhfV1OCg8+88xO77cj8rH8=",
 			"origin": "github.com/aws/aws-sdk-go/vendor/github.com/go-ini/ini",
 			"path": "github.com/go-ini/ini",
-			"revision": "2518e87b4936ee9928eadf38957b1fd86e25052c",
-			"revisionTime": "2017-04-03T20:52:32Z"
+			"revision": "538c13abafdd1d2103dcfe8c0be8a584bd25502a",
+			"revisionTime": "2017-04-19T23:58:17Z"
+		},
+		{
+			"checksumSHA1": "axNNGK9AXZzNOCfYfG0qiYfdTYc=",
+			"path": "github.com/gopherjs/gopherjs/js",
+			"revision": "3496c6f94e1b945f3fc9580f6982675c0a74cd6c",
+			"revisionTime": "2017-03-27T17:11:18Z"
 		},
 		{
 			"checksumSHA1": "TDeiKiCXvRCyaC5uBryv5Av5SMk=",
@@ -270,11 +276,53 @@
 			"revisionTime": "2017-04-03T20:52:32Z"
 		},
 		{
+			"checksumSHA1": "3tpCIywCgmASqlnNyJ16XXSpzMw=",
+			"path": "github.com/jtolds/gls",
+			"revision": "bb0351aa7eb6f322f32667d51375f26a2bca6628",
+			"revisionTime": "2016-12-28T00:43:38Z"
+		},
+		{
 			"checksumSHA1": "zKKp5SZ3d3ycKe4EKMNT0BqAWBw=",
 			"origin": "github.com/stretchr/testify/vendor/github.com/pmezard/go-difflib/difflib",
 			"path": "github.com/pmezard/go-difflib/difflib",
 			"revision": "18a02ba4a312f95da08ff4cfc0055750ce50ae9e",
 			"revisionTime": "2016-11-17T07:43:51Z"
+		},
+		{
+			"checksumSHA1": "BpFbfnxs4jrjGldU6aMIMcrDmXM=",
+			"path": "github.com/smartystreets/assertions",
+			"revision": "c9ee7d9e9a2aeec0bee7c4a516f3e0ad7cb7e558",
+			"revisionTime": "2017-02-13T16:53:18Z"
+		},
+		{
+			"checksumSHA1": "Vzb+dEH/LTYbvr8RXHmt6xJHz04=",
+			"path": "github.com/smartystreets/assertions/internal/go-render/render",
+			"revision": "c9ee7d9e9a2aeec0bee7c4a516f3e0ad7cb7e558",
+			"revisionTime": "2017-02-13T16:53:18Z"
+		},
+		{
+			"checksumSHA1": "r6FauVdOTFnwYQgrKGFuWUbIAJE=",
+			"path": "github.com/smartystreets/assertions/internal/oglematchers",
+			"revision": "c9ee7d9e9a2aeec0bee7c4a516f3e0ad7cb7e558",
+			"revisionTime": "2017-02-13T16:53:18Z"
+		},
+		{
+			"checksumSHA1": "KYSYYlW1zv3HfpbNSLJpDYj5rJE=",
+			"path": "github.com/smartystreets/goconvey/convey",
+			"revision": "3bd662eac601ad6436e64776af2e112069eb2edc",
+			"revisionTime": "2017-01-10T12:00:22Z"
+		},
+		{
+			"checksumSHA1": "2x3M0H7g69Yul0dydYqLklCFDDA=",
+			"path": "github.com/smartystreets/goconvey/convey/gotest",
+			"revision": "3bd662eac601ad6436e64776af2e112069eb2edc",
+			"revisionTime": "2017-01-10T12:00:22Z"
+		},
+		{
+			"checksumSHA1": "/Vf/BK8DEzagv141VuY7P1UtI40=",
+			"path": "github.com/smartystreets/goconvey/convey/reporting",
+			"revision": "3bd662eac601ad6436e64776af2e112069eb2edc",
+			"revisionTime": "2017-01-10T12:00:22Z"
 		},
 		{
 			"checksumSHA1": "FQxphxs1ORrfgfaeVz34UvgV+/8=",
@@ -294,5 +342,5 @@
 			"revisionTime": "2015-01-19T16:55:52-02:00"
 		}
 	],
-	"rootPath": "github.com/remind101/assume-role"
+	"rootPath": "assume-role"
 }


### PR DESCRIPTION
First go code, so feedback welcome.  I don't understand why it added those new packages to vendor/ but didn't seem to copy go-ini, so...

Fix for https://github.com/remind101/assume-role/issues/7 .  Tested with both
~/.aws/config and ~/.aws/roles.  Did NOT test that a ~/.aws/config profile that
doesn't have an MFA token works since it would have required setting up test
users on my side.  I did test that it can parse an entry that doesn't have an
MFA and sets the value in the map to nil.  If that is what the YAML parser does
it should work.

Prints a deprecation warning if running against ~/.aws/roles.

- Add gp-ini/ini dependency to vendors (https://github.com/go-ini/ini)
- Move old loadConfig to loadConfigFromRoleFile
- Add new loadConfigFromConfigFile function
- Make new loadConfig function that delegates to the other two
- Run go fmt