### PR TITLE
add Windows powershell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,20 @@ export AWS_ACCESS_KEY_ID="ASIAI....UOCA"
 export AWS_SECRET_ACCESS_KEY="DuH...G1d"
 export AWS_SESSION_TOKEN="AQ...1BQ=="
 export AWS_SECURITY_TOKEN="AQ...1BQ=="
+export ASSUMED_ROLE="prod"
 # Run this to configure your shell:
 # eval $(assume-role prod)
+```
+
+Or windows:
+```cmd
+$env:AWS_ACCESS_KEY_ID="ASIAI....UOCA"
+$env:AWS_SECRET_ACCESS_KEY="DuH...G1d"
+$env:AWS_SESSION_TOKEN="AQ...1BQ=="
+$env:AWS_SECURITY_TOKEN="AQ...1BQ=="
+$env:ASSUMED_ROLE="prod"
+# Run this to configure your shell:
+# assume-role.exe prod | Invoke-Expression
 ```
 
 ## TODO


### PR DESCRIPTION
 via `printWindowsCredentials()` 

Basically just prints out:

```
$env:AWS_ACCESS_KEY_ID="ASIAI....UOCA"
$env:AWS_SECRET_ACCESS_KEY="DuH...G1d"
$env:AWS_SESSION_TOKEN="AQ...1BQ=="
$env:AWS_SECURITY_TOKEN="AQ...1BQ=="
$env:ASSUMED_ROLE="prod"
```

which can then be configured using `assume-role <role> | Invoke-Expression`

I've used this on Windows to deploy my AWS lambdas and it's working fine. Also tested on Mac to ensure nothing is broken. If the code is merged, I can add the binary to https://github.com/lukesampson/scoop so that Windows users can just `scoop install assume-role`