### PR TITLE
export flag to force use of bash-style export statements

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,12 +34,17 @@ func init() {
 func main() {
 	var (
 		duration = flag.Duration("duration", time.Hour, "The duration that the credentials will be valid for.")
-		export   = flag.Bool("export", false, "If true, forces the use of bash/shell export statements that can be sourced")
+		format   = flag.String("format", "", "Format can be 'bash' or 'powershell'. Default format is based on operating system.")
 	)
 
 	flag.Parse()
 	argv := flag.Args()
 	if len(argv) < 1 {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	if *format != "" && *format != "bash" && *format != "powershell" {
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -81,9 +86,9 @@ func main() {
 	}
 
 	if len(args) == 0 {
-		if !*export && runtime.GOOS == "windows" {
+		if *format == "powershell" || (*format == "" && runtime.GOOS == "windows") {
 			printWindowsCredentials(role, creds)
-		} else {
+		} else { // *format == "bash"
 			printCredentials(role, creds)
 		}
 		return

--- a/main.go
+++ b/main.go
@@ -31,10 +31,19 @@ func init() {
 	flag.Usage = usage
 }
 
+func defaultFormat() string {
+	switch runtime.GOOS {
+	case "windows":
+		return "powershell"
+	default:
+		return "bash"
+	}
+}
+
 func main() {
 	var (
 		duration = flag.Duration("duration", time.Hour, "The duration that the credentials will be valid for.")
-		format   = flag.String("format", "", "Format can be 'bash' or 'powershell'. Default format is based on operating system.")
+		format   = flag.String("format", defaultFormat(), "Format can be 'bash' or 'powershell'.")
 	)
 
 	flag.Parse()
@@ -42,15 +51,6 @@ func main() {
 	if len(argv) < 1 {
 		flag.Usage()
 		os.Exit(1)
-	}
-
-	if *format == "" {
-		switch runtime.GOOS {
-		case "windows":
-			*format = "powershell"
-		default:
-			*format = "bash"
-		}
 	}
 
 	stscreds.DefaultDuration = *duration

--- a/main.go
+++ b/main.go
@@ -44,9 +44,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	if *format != "" && *format != "bash" && *format != "powershell" {
-		flag.Usage()
-		os.Exit(1)
+	if *format == "" {
+		switch runtime.GOOS {
+		case "windows":
+			*format = "powershell"
+		default:
+			*format = "bash"
+		}
 	}
 
 	stscreds.DefaultDuration = *duration
@@ -86,10 +90,14 @@ func main() {
 	}
 
 	if len(args) == 0 {
-		if *format == "powershell" || (*format == "" && runtime.GOOS == "windows") {
+		switch *format {
+		case "powershell":
 			printWindowsCredentials(role, creds)
-		} else { // *format == "bash"
+		case "bash":
 			printCredentials(role, creds)
+		default:
+			flag.Usage()
+			os.Exit(1)
 		}
 		return
 	}


### PR DESCRIPTION
After trying a variety of ways to tell if the user is powershell vs bash vs cmd vs other shells (especially since powershell is on linux now, and I'm using mingw/mintty bash on windows), I decided to just make it a flag.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/remind101/assume-role/17)
<!-- Reviewable:end -->
