### PR TITLE
Allow assuming role arn with shared config

### DIFF
--- a/main.go
+++ b/main.go
@@ -183,7 +183,9 @@ func assumeProfile(profile string) (*credentials.Value, error) {
 
 // assumeRole assumes the given role and returns the temporary STS credentials.
 func assumeRole(role, mfa string, duration time.Duration) (*credentials.Value, error) {
-	sess := session.Must(session.NewSession())
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
 
 	svc := sts.New(sess)
 


### PR DESCRIPTION
Assuming role ARN from the command line does not read shared config, so if my source profile is activated with `AWS_PROFILE`, assume-role will fail.

This PR fixes that by enabling shared config for assumeRole session.