### PR TITLE
bugfix: Updating ARN regex to handle non-standard regions

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	configFilePath = fmt.Sprintf("%s/.aws/roles", os.Getenv("HOME"))
-	roleArnRe      = regexp.MustCompile(`^arn:aws:iam::(.+):role/([^/]+)(/.+)?$`)
+	roleArnRe      = regexp.MustCompile(`^arn:aws(-((cn)|(us-gov)))?:iam::(.+):role/([^/]+)(/.+)?$`)
 )
 
 func usage() {


### PR DESCRIPTION
Changing the regex scrip to handle the ARN format in non-standard AWS regions.

The ARN format used in AWS China and GovCloud is different than in other regions.